### PR TITLE
SGA V2 writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ obj/
 bin/
 _site/
 /docs/api
+
+# Ignore temporary testing files
+output.bin

--- a/OpenCompote.Cli/Program.cs
+++ b/OpenCompote.Cli/Program.cs
@@ -19,31 +19,31 @@ if (args.Length == 0)
 
 string sgaPath = args[0];
 
-// using(var newSga = new SgaArchive(new MemoryStream(), SgaMode.Create, SgaVersion.V2))
-// {
-//     newSga.ArchiveName = "MyNewArchive";
-//     var dataDrive = newSga.AddDrive("data", "gameData");
-//     var attrDrive = newSga.AddDrive("attribs", "gameAttributes");
-
-//     dataDrive.RootFolder.Name = ""; 
-//     var subfolder = dataDrive.RootFolder.AddFolder("subfolder");   
-//     subfolder.AddFolder("subsubFolder");
-//     subfolder.AddFolder("folder2");
-//     var file1 = subfolder.AddFile("file1", StorageType.Uncompress);
-//     var fileStream = file1.Open();
-
-//     using(var fileWriter = new StreamWriter(fileStream, leaveOpen: true))
-//     {
-//         fileWriter.WriteLine("Hello world!");        
-//     }
-
-//     Console.WriteLine(fileStream.Position);
-//     fileStream.Position = 0;
-//     Console.WriteLine(fileStream.ReadByte());
-// }
-
-using (SgaArchive archive = SgaArchiveFile.Open(sgaPath, SgaMode.Write))
+using(var newSga = new SgaArchive(new MemoryStream(), SgaMode.Create, SgaVersion.V2))
 {
-    Console.WriteLine(archive.ArchiveName);
-    archive.ArchiveName = "";
+    newSga.ArchiveName = "MyNewArchive";
+    var dataDrive = newSga.AddDrive("data", "gameData");
+    var attrDrive = newSga.AddDrive("attribs", "gameAttributes");
+
+    dataDrive.RootFolder.Name = ""; 
+    var subfolder = dataDrive.RootFolder.AddFolder("subfolder");   
+    subfolder.AddFolder("subsubFolder");
+    subfolder.AddFolder("folder2");
+    var file1 = subfolder.AddFile("file1", StorageType.Uncompress);
+    var fileStream = file1.Open();
+
+    using(var fileWriter = new StreamWriter(fileStream, leaveOpen: true))
+    {
+        fileWriter.WriteLine("Hello world!");        
+    }
+
+    Console.WriteLine(fileStream.Position);
+    fileStream.Position = 0;
+    Console.WriteLine(fileStream.ReadByte());
 }
+
+// using (SgaArchive archive = SgaArchiveFile.Open(sgaPath, SgaMode.Write))
+// {
+//     Console.WriteLine(archive.ArchiveName);
+//     archive.ArchiveName = "";
+// }

--- a/OpenCompote.Cli/Program.cs
+++ b/OpenCompote.Cli/Program.cs
@@ -19,31 +19,31 @@ if (args.Length == 0)
 
 string sgaPath = args[0];
 
-using(var newSga = new SgaArchive(new MemoryStream(), SgaMode.Create, SgaVersion.V2))
-{
-    newSga.ArchiveName = "MyNewArchive";
-    var dataDrive = newSga.AddDrive("data", "gameData");
-    var attrDrive = newSga.AddDrive("attribs", "gameAttributes");
-
-    dataDrive.RootFolder.Name = ""; 
-    var subfolder = dataDrive.RootFolder.AddFolder("subfolder");   
-    subfolder.AddFolder("subsubFolder");
-    subfolder.AddFolder("folder2");
-    var file1 = subfolder.AddFile("file1", StorageType.Uncompress);
-    var fileStream = file1.Open();
-
-    using(var fileWriter = new StreamWriter(fileStream, leaveOpen: true))
-    {
-        fileWriter.WriteLine("Hello world!");        
-    }
-
-    Console.WriteLine(fileStream.Position);
-    fileStream.Position = 0;
-    Console.WriteLine(fileStream.ReadByte());
-}
-
-// using (SgaArchive archive = SgaArchiveFile.Open(sgaPath, SgaMode.Write))
+// using(var newSga = new SgaArchive(new MemoryStream(), SgaMode.Create, SgaVersion.V2))
 // {
-//     Console.WriteLine(archive.ArchiveName);
-//     archive.ArchiveName = "";
+//     newSga.ArchiveName = "MyNewArchive";
+//     var dataDrive = newSga.AddDrive("data", "gameData");
+//     var attrDrive = newSga.AddDrive("attribs", "gameAttributes");
+
+//     dataDrive.RootFolder.Name = ""; 
+//     var subfolder = dataDrive.RootFolder.AddFolder("subfolder");   
+//     subfolder.AddFolder("subsubFolder");
+//     subfolder.AddFolder("folder2");
+//     var file1 = subfolder.AddFile("file1", StorageType.Uncompress);
+//     var fileStream = file1.Open();
+
+//     using(var fileWriter = new StreamWriter(fileStream, leaveOpen: true))
+//     {
+//         fileWriter.WriteLine("Hello world!");        
+//     }
+
+//     Console.WriteLine(fileStream.Position);
+//     fileStream.Position = 0;
+//     Console.WriteLine(fileStream.ReadByte());
 // }
+
+using (SgaArchive archive = SgaArchiveFile.Open(sgaPath, SgaMode.Write))
+{
+    //Console.WriteLine(archive.ArchiveName);
+    //archive.ArchiveName = "";
+}

--- a/OpenCompote.Cli/Program.cs
+++ b/OpenCompote.Cli/Program.cs
@@ -19,31 +19,32 @@ if (args.Length == 0)
 
 string sgaPath = args[0];
 
-// using(var newSga = new SgaArchive(new MemoryStream(), SgaMode.Create, SgaVersion.V2))
-// {
-//     newSga.ArchiveName = "MyNewArchive";
-//     var dataDrive = newSga.AddDrive("data", "gameData");
-//     var attrDrive = newSga.AddDrive("attribs", "gameAttributes");
+using(var newSga = new SgaArchive(new FileStream("output.sga", FileMode.Create, FileAccess.ReadWrite), SgaMode.Create, SgaVersion.V2))
+{
+    newSga.ArchiveName = "MyNewArchive";
+    var dataDrive = newSga.AddDrive("data", "gameData");
+    var attrDrive = newSga.AddDrive("attribs", "gameAttributes");
 
-//     dataDrive.RootFolder.Name = ""; 
-//     var subfolder = dataDrive.RootFolder.AddFolder("subfolder");   
-//     subfolder.AddFolder("subsubFolder");
-//     subfolder.AddFolder("folder2");
-//     var file1 = subfolder.AddFile("file1", StorageType.Uncompress);
-//     var fileStream = file1.Open();
+    dataDrive.RootFolder.Name = ""; 
+    var subfolder = dataDrive.RootFolder.AddFolder("subfolder");
+    subfolder.AddFolder("subsubFolder");
+    subfolder.AddFolder("folder2");
+    var file1 = subfolder.AddFile("file1.txt", StorageType.Uncompress);
+    using var fileStream = file1.Open();
 
-//     using(var fileWriter = new StreamWriter(fileStream, leaveOpen: true))
-//     {
-//         fileWriter.WriteLine("Hello world!");        
-//     }
+    using(var fileWriter = new StreamWriter(fileStream, leaveOpen: true))
+    {
+        fileWriter.Write("Hello world!");
+    }
 
-//     Console.WriteLine(fileStream.Position);
-//     fileStream.Position = 0;
-//     Console.WriteLine(fileStream.ReadByte());
-// }
+    Console.WriteLine(fileStream.Position);
+    fileStream.Position = 0;
+    Console.WriteLine(fileStream.ReadByte());
+}
+
+Console.WriteLine();
 
 using (SgaArchive archive = SgaArchiveFile.Open(sgaPath, SgaMode.Write))
 {
-    //Console.WriteLine(archive.ArchiveName);
-    //archive.ArchiveName = "";
+    //var drive = archive.GetDrive("gameData");
 }

--- a/OpenCompote.Cli/Properties/launchSettings.json
+++ b/OpenCompote.Cli/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "OpenCompote.Cli": {
       "commandName": "Project",
       "workingDirectory": "..",
-      "commandLineArgs": "\"../sgas/W40kDataLoc(dow1).sga\""
+      "commandLineArgs": "\"W40kDataLoc(dow1).sga\""
     }
   }
 }

--- a/OpenCompote.Cli/Properties/launchSettings.json
+++ b/OpenCompote.Cli/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "OpenCompote.Cli": {
       "commandName": "Project",
       "workingDirectory": "..",
-      "commandLineArgs": "\"W40kDataLoc(dow1).sga\""
+      "commandLineArgs": "\"output.sga\""
     }
   }
 }

--- a/OpenCompote/CustomStreams/WrapperStream.cs
+++ b/OpenCompote/CustomStreams/WrapperStream.cs
@@ -98,6 +98,8 @@ internal sealed class WrapperStream : Stream
 
             if (_closeBaseStream)
                 _baseStream.Dispose();
+            else
+                _baseStream.Position = 0;
 
             _isDisposed = true;
         }

--- a/OpenCompote/Parsers/ParserUtils.cs
+++ b/OpenCompote/Parsers/ParserUtils.cs
@@ -14,14 +14,14 @@ internal static class ParserUtils
 
     public static string ReadWideStaticString(Stream sgaFile, int length)
     {
-        byte[] strBuffer = new byte[length];
+        byte[] strBuffer = new byte[length*2];
         sgaFile.ReadExactly(strBuffer);
         return System.Text.Encoding.Unicode.GetString(strBuffer).TrimEnd('\0');
     }
 
     public static void WriteWideStaticString(Stream sgaFile, string inputString, int length)
     {
-        byte[] buffer = new byte[length];
+        byte[] buffer = new byte[length*2];
         System.Text.Encoding.Unicode.GetBytes(inputString, buffer);
         sgaFile.Write(buffer);
     }

--- a/OpenCompote/Parsers/ParserUtils.cs
+++ b/OpenCompote/Parsers/ParserUtils.cs
@@ -19,11 +19,25 @@ internal static class ParserUtils
         return System.Text.Encoding.Unicode.GetString(strBuffer).TrimEnd('\0');
     }
 
+    public static void WriteWideStaticString(Stream sgaFile, string inputString, int length)
+    {
+        byte[] buffer = new byte[length];
+        System.Text.Encoding.Unicode.GetBytes(inputString, buffer);
+        sgaFile.Write(buffer);
+    }
+
     public static string ReadStaticString(Stream sgaFile, int length)
     {
         byte[] strBuffer = new byte[length];
         sgaFile.ReadExactly(strBuffer);
         return System.Text.Encoding.UTF8.GetString(strBuffer).TrimEnd('\0');
+    }
+
+    public static void WriteStaticString(Stream sgaFile, string inputString, int length)
+    {
+        byte[] buffer = new byte[length];
+        System.Text.Encoding.UTF8.GetBytes(inputString, buffer);
+        sgaFile.Write(buffer);
     }
 
     public static string ReadDynamicString(Stream sgaFile, long startPosition)
@@ -45,6 +59,13 @@ internal static class ParserUtils
         return System.Text.Encoding.ASCII.GetString(buffer.ToArray());
     }
 
+    public static void WriteDynamicString(Stream sgaFile, string inputString)
+    {
+        byte[] bytes = new byte[inputString.Length + 1];
+        System.Text.Encoding.UTF8.GetBytes(inputString, bytes);
+        sgaFile.Write(bytes);
+    }
+
     public static uint ReadUInt32(Stream sgaFile)
     {
         byte[] numBuffer = new byte[4];
@@ -52,11 +73,25 @@ internal static class ParserUtils
         return BinaryPrimitives.ReadUInt32LittleEndian(numBuffer);
     }
 
+    public static void WriteUInt32(Stream sgaFile, uint value)
+    {
+        byte[] numBuffer = new byte[4];
+        BinaryPrimitives.WriteUInt32LittleEndian(numBuffer,value);
+        sgaFile.Write(numBuffer);
+    }
+
     public static ushort ReadUInt16(Stream sgaFile)
     {
         byte[] numBuffer = new byte[2];
         sgaFile.ReadExactly(numBuffer);
         return BinaryPrimitives.ReadUInt16LittleEndian(numBuffer);
+    }
+
+    public static void WriteUInt16(Stream sgaFile, ushort value)
+    {
+        byte[] numBuffer = new byte [2];
+        BinaryPrimitives.WriteUInt16LittleEndian(numBuffer, value);
+        sgaFile.Write(numBuffer);
     }
 
     public static byte[]? HashMD5(Stream fileStream, long dataLength, string initialValue )

--- a/OpenCompote/Parsers/SgaV2Parser.cs
+++ b/OpenCompote/Parsers/SgaV2Parser.cs
@@ -5,15 +5,6 @@ using OpenCompote.SGA.Parsers.Structs;
 
 namespace OpenCompote.SGA.Parsers;
 
-internal struct DriveTest(SgaDrive drive)
-{
-    public SgaDrive Drive { get; set; } = drive;
-    public ushort FirstFolder {get; set;}
-    public ushort LastFolder {get; set;}
-    public ushort FirstFile {get; set;}
-    public ushort LastFile {get; set;}
-}
-
 internal class FolderTest(SgaFolder folder)
 {
     public SgaFolder Folder { get; set; } = folder;
@@ -28,6 +19,8 @@ internal class SgaV2Parser : ISgaParser
     private const int DRIVE_SIZE = 138;
     private const int FOLDER_SIZE = 12;
     private const int FILE_SIZE = 20;
+    private const int ARCHIVE_NAME_LENGTH = 64;
+    private const int FILE_HEADER_SIZE = 180;
 
     public void Parse(SgaArchive archive, Stream sgaStream)
     {
@@ -37,7 +30,7 @@ internal class SgaV2Parser : ISgaParser
 
         byte[] fileHash = ParserUtils.ReadHash(sgaStream);
 
-        archive._archiveName = ParserUtils.ReadWideStaticString(sgaStream, 128);
+        archive._archiveName = ParserUtils.ReadWideStaticString(sgaStream, ARCHIVE_NAME_LENGTH);
 
         byte[] tocHash = ParserUtils.ReadHash(sgaStream);
 
@@ -51,13 +44,6 @@ internal class SgaV2Parser : ISgaParser
         byte[]? generatedTocHash = ParserUtils.HashMD5(sgaStream, tocSize, "DFC9AF62-FC1B-4180-BC27-11CCE87D3EFF");
         if(generatedTocHash == null || !tocHash.SequenceEqual(generatedTocHash))
             Console.WriteLine("Hash is  not valid");
-
-        // var curPosition = sgaStream.Position;
-        // using var tempStream = new FileStream("toc.bin", FileMode.Create, FileAccess.Write);
-        // byte[] buffer = new byte[tocSize];
-        // sgaStream.ReadExactly(buffer);
-        // sgaStream.Position = curPosition;
-        // tempStream.Write(buffer);
 
         // Read TOC header
         uint driveOffset = ParserUtils.ReadUInt32(sgaStream);
@@ -166,24 +152,19 @@ internal class SgaV2Parser : ISgaParser
 
     public void Write(SgaArchive archive, Stream sgaStream)
     {
-        // Currently writing directly into specific file. Only for testing. The final implementation will not use hardcoded paths.
-        //using var tempStream = new FileStream("output.bin", FileMode.Create, FileAccess.Write); 
-        LogArchive(archive);
+        //LogArchive(archive); //Used for debugging
         using var tempStream = new MemoryStream();
 
-        // Flatten drives folders and files so that folder/file indices are contiguous per-drive
-        List<DriveTest> driveList = new List<DriveTest>();
+        List<DriveRecord> driveList = new List<DriveRecord>();
         List<FolderTest> folderList = new List<FolderTest>();
         List<SgaFile> fileList = new List<SgaFile>();
 
-        // We'll traverse drives in order and append their folder trees
+        // Traverse drives and append their folder trees
         foreach (var drive in archive._drives)
         {
-            // iterative preorder traversal to produce folderList
             var stack = new Stack<FolderTest>();
-            var driveTest = new DriveTest(drive);
-            driveTest.FirstFolder = (ushort)folderList.Count;
-            driveTest.FirstFile = (ushort)fileList.Count;
+            ushort firstFolder = (ushort)folderList.Count;
+            ushort firstFile = (ushort)fileList.Count;
 
             if (drive.RootFolder != null)
             {
@@ -222,10 +203,7 @@ internal class SgaV2Parser : ISgaParser
                 f.LastFile = (ushort)fileList.Count;
                 
             }
-
-            driveTest.LastFolder = (ushort)folderList.Count;
-            driveTest.LastFile = (ushort)fileList.Count;
-            driveList.Add(driveTest);
+            driveList.Add(new DriveRecord(drive.Name, drive.Alias, firstFolder, (ushort)folderList.Count, firstFile ,(ushort)fileList.Count, 0));
         }
 
         
@@ -236,6 +214,7 @@ internal class SgaV2Parser : ISgaParser
         uint fileOffset = folderOffset + (uint)folderList.Count * FOLDER_SIZE;
         uint nameOffset = fileOffset + (uint)fileList.Count * FILE_SIZE;
 
+        // Write TOC Header
         ParserUtils.WriteUInt32(toc, 24);                               // Drive offset
         ParserUtils.WriteUInt16(toc, (ushort)driveList.Count);          // Drive count
         ParserUtils.WriteUInt32(toc, folderOffset);                     // Folder offset
@@ -248,8 +227,8 @@ internal class SgaV2Parser : ISgaParser
         // Write drives
         foreach (var drive in driveList)
         {
-            ParserUtils.WriteStaticString(toc, drive.Drive.Name, 64);
-            ParserUtils.WriteStaticString(toc, drive.Drive.Alias, 64);
+            ParserUtils.WriteStaticString(toc, drive.DriveName, 64);
+            ParserUtils.WriteStaticString(toc, drive.DriveAlias, 64);
             ParserUtils.WriteUInt16(toc, drive.FirstFolder);
             ParserUtils.WriteUInt16(toc, drive.LastFolder);
             ParserUtils.WriteUInt16(toc, drive.FirstFile);
@@ -257,6 +236,7 @@ internal class SgaV2Parser : ISgaParser
             ParserUtils.WriteUInt16(toc, drive.FirstFolder);
         }
 
+        // Write folders
         foreach (var f in folderList)
         {
             uint folderNameOffset = (uint)nameBuffer.Position;
@@ -269,8 +249,8 @@ internal class SgaV2Parser : ISgaParser
             ParserUtils.WriteUInt16(toc, f.LastFile);
         }
 
-        uint dataOffset = 264;
-        // Write file records placeholders (nameOffset, storageFlag, dataOffset, compressedSize, decompressedSize)
+        uint dataOffset = 264; // Add temporary Data offset buffer for the optional file info. This will be replaced later.
+        // Write Files
         foreach (var f in fileList)
         {
             uint folderNameOffset = (uint)nameBuffer.Position;
@@ -289,25 +269,33 @@ internal class SgaV2Parser : ISgaParser
         nameBuffer.Seek(0, SeekOrigin.Begin);
         nameBuffer.CopyTo(toc);
         toc.Seek(0, SeekOrigin.Begin);
+
         byte[]? tocHash = ParserUtils.HashMD5(toc, toc.Length, "DFC9AF62-FC1B-4180-BC27-11CCE87D3EFF");
 
-        ParserUtils.WriteStaticString(tempStream, "_ARCHIVE", 8);
-        ParserUtils.WriteUInt32(tempStream, (uint)archive.Version);
+
+        // Start writing actual file it self.
+        ParserUtils.WriteStaticString(tempStream, "_ARCHIVE", 8); // Write magic world 
+        ParserUtils.WriteUInt32(tempStream, (uint)archive.Version); // Write archive version
         
+        // Temporarily fill the template hash with zeroes.
         byte[] emptyHash = new byte[16];
-        tempStream.Write(emptyHash);
+        tempStream.Write(emptyHash); 
         
-        ParserUtils.WriteWideStaticString(tempStream, archive.ArchiveName, 128);
+        // Write Archive name
+        ParserUtils.WriteWideStaticString(tempStream, archive.ArchiveName, ARCHIVE_NAME_LENGTH);
         
+        //Write TOC hash
         tempStream.Write(tocHash);
         
-        ParserUtils.WriteUInt32(tempStream, (uint)toc.Length);
-        ParserUtils.WriteUInt32(tempStream, (uint)(toc.Length + 180 ));
+        // Write the rest of the file header
+        ParserUtils.WriteUInt32(tempStream, (uint)toc.Length); // TOC size
+        ParserUtils.WriteUInt32(tempStream, (uint)(toc.Length + FILE_HEADER_SIZE)); // Data offset
         
-        toc.CopyTo(tempStream);
+        toc.CopyTo(tempStream); // copy the TOC to the new archive
 
         byte[] emptyMetaData = new byte[264];
 
+        // Write the actual content of the files.
         foreach(var file in fileList)
         {
             tempStream.Write(emptyMetaData);
@@ -315,19 +303,22 @@ internal class SgaV2Parser : ISgaParser
             contents.CopyTo(tempStream);
         }
 
+        // Calculate the File hash
         tempStream.Position = 180;
         byte[]? fileHash = ParserUtils.HashMD5(tempStream, tempStream.Length-tempStream.Position, "E01519D6-2DB7-4640-AF54-0A23319C56C3");
         
+        // Write the file hash
         tempStream.Position = 12;
         tempStream.Write(fileHash);
 
+        // Copy the new archive to the original position.
         sgaStream.Position = 0;
         tempStream.Position = 0;
         tempStream.CopyTo(sgaStream);
         sgaStream.SetLength(sgaStream.Position);
     }
 
-    // Mock implementation. For testing only. Will be replaces by actual implementation when i will be satisfied by the public interface.
+    // Mock logging. For testing only. this will be replaces when i will be finished with writer.
     private static void LogArchive(SgaArchive archive)
     {
         Console.WriteLine("Archive name: {0}",archive.ArchiveName);

--- a/OpenCompote/Parsers/SgaV2Parser.cs
+++ b/OpenCompote/Parsers/SgaV2Parser.cs
@@ -5,22 +5,22 @@ using OpenCompote.SGA.Parsers.Structs;
 
 namespace OpenCompote.SGA.Parsers;
 
-internal class FolderTest(SgaFolder folder)
-{
-    public SgaFolder Folder { get; set; } = folder;
-    public ushort FirstFolder {get; set;}
-    public ushort LastFolder {get; set;}
-    public ushort FirstFile {get; set;}
-    public ushort LastFile {get; set;}
-}
-
 internal class SgaV2Parser : ISgaParser
 {
+    // Archive record sizes
     private const int DRIVE_SIZE = 138;
     private const int FOLDER_SIZE = 12;
     private const int FILE_SIZE = 20;
-    private const int ARCHIVE_NAME_LENGTH = 64;
+
     private const int FILE_HEADER_SIZE = 180;
+
+    // Static length name lengths
+    private const int ARCHIVE_NAME_LENGTH = 64;
+    private const int DRIVE_NAME_LENGTH = 64;
+
+    // MD5 default hashes
+    private const string TOC_HASH_INIT = "DFC9AF62-FC1B-4180-BC27-11CCE87D3EFF";
+    private const string FILE_HASH_INIT = "E01519D6-2DB7-4640-AF54-0A23319C56C3";
 
     public void Parse(SgaArchive archive, Stream sgaStream)
     {
@@ -37,11 +37,11 @@ internal class SgaV2Parser : ISgaParser
         uint tocSize = ParserUtils.ReadUInt32(sgaStream);
         uint dataOffset = ParserUtils.ReadUInt32(sgaStream);
 
-        byte[]? generatedFileHash = ParserUtils.HashMD5(sgaStream, sgaStream.Length-sgaStream.Position, "E01519D6-2DB7-4640-AF54-0A23319C56C3");
+        byte[]? generatedFileHash = ParserUtils.HashMD5(sgaStream, sgaStream.Length-sgaStream.Position, FILE_HASH_INIT);
         if(generatedFileHash == null || !fileHash.SequenceEqual(generatedFileHash))
             Console.WriteLine("Hash is not valid");
 
-        byte[]? generatedTocHash = ParserUtils.HashMD5(sgaStream, tocSize, "DFC9AF62-FC1B-4180-BC27-11CCE87D3EFF");
+        byte[]? generatedTocHash = ParserUtils.HashMD5(sgaStream, tocSize, TOC_HASH_INIT);
         if(generatedTocHash == null || !tocHash.SequenceEqual(generatedTocHash))
             Console.WriteLine("Hash is  not valid");
 
@@ -61,8 +61,8 @@ internal class SgaV2Parser : ISgaParser
         for (int i = 0; i < driveCount; i++)
         {
             DriveRecord internalDrive = new DriveRecord(
-                ParserUtils.ReadStaticString(sgaStream, 64),
-                ParserUtils.ReadStaticString(sgaStream, 64),
+                ParserUtils.ReadStaticString(sgaStream, DRIVE_NAME_LENGTH),
+                ParserUtils.ReadStaticString(sgaStream, DRIVE_NAME_LENGTH),
                 ParserUtils.ReadUInt16(sgaStream),
                 ParserUtils.ReadUInt16(sgaStream),
                 ParserUtils.ReadUInt16(sgaStream),
@@ -115,7 +115,7 @@ internal class SgaV2Parser : ISgaParser
                 FolderRecord currentRecord = item.Item1;
                 SgaFolder? parent = item.Item2;
                 
-                uint nameStart = currentRecord.NameOffset + 180 + nameListOffset;
+                uint nameStart = currentRecord.NameOffset + FILE_HEADER_SIZE + nameListOffset;
                 string folderName = ParserUtils.ReadDynamicString(sgaStream, nameStart);
 
                 SgaFolder currentFolder = new SgaFolder(folderName, newDrive, parent);
@@ -134,7 +134,7 @@ internal class SgaV2Parser : ISgaParser
                 {
                     FileRecord fileRecord = fileList[i];
 
-                    uint fileNameOffset = fileRecord.NameOffset + 180 + nameListOffset;
+                    uint fileNameOffset = fileRecord.NameOffset + FILE_HEADER_SIZE + nameListOffset;
                     string fileName = ParserUtils.ReadDynamicString(sgaStream, fileNameOffset);
 
                     SgaFile currentFile = new SgaFile(fileName,
@@ -156,19 +156,19 @@ internal class SgaV2Parser : ISgaParser
         using var tempStream = new MemoryStream();
 
         List<DriveRecord> driveList = new List<DriveRecord>();
-        List<FolderTest> folderList = new List<FolderTest>();
+        List<FolderWriterRecord> folderList = new List<FolderWriterRecord>();
         List<SgaFile> fileList = new List<SgaFile>();
 
         // Traverse drives and append their folder trees
         foreach (var drive in archive._drives)
         {
-            var stack = new Stack<FolderTest>();
+            var stack = new Stack<FolderWriterRecord>();
             ushort firstFolder = (ushort)folderList.Count;
             ushort firstFile = (ushort)fileList.Count;
 
             if (drive.RootFolder != null)
             {
-                FolderTest folderTest = new FolderTest(drive.RootFolder);
+                FolderWriterRecord folderTest = new FolderWriterRecord(drive.RootFolder);
                 stack.Push(folderTest);
                 folderList.Add(folderTest);
             }
@@ -191,7 +191,7 @@ internal class SgaV2Parser : ISgaParser
 
                     if (e is SgaFolder childFolder)
                     {
-                        FolderTest child = new FolderTest(childFolder);
+                        FolderWriterRecord child = new FolderWriterRecord(childFolder);
                         folderList.Add(child);
                     }
                 }
@@ -227,8 +227,8 @@ internal class SgaV2Parser : ISgaParser
         // Write drives
         foreach (var drive in driveList)
         {
-            ParserUtils.WriteStaticString(toc, drive.DriveName, 64);
-            ParserUtils.WriteStaticString(toc, drive.DriveAlias, 64);
+            ParserUtils.WriteStaticString(toc, drive.DriveName, DRIVE_NAME_LENGTH);
+            ParserUtils.WriteStaticString(toc, drive.DriveAlias, DRIVE_NAME_LENGTH);
             ParserUtils.WriteUInt16(toc, drive.FirstFolder);
             ParserUtils.WriteUInt16(toc, drive.LastFolder);
             ParserUtils.WriteUInt16(toc, drive.FirstFile);
@@ -270,7 +270,7 @@ internal class SgaV2Parser : ISgaParser
         nameBuffer.CopyTo(toc);
         toc.Seek(0, SeekOrigin.Begin);
 
-        byte[]? tocHash = ParserUtils.HashMD5(toc, toc.Length, "DFC9AF62-FC1B-4180-BC27-11CCE87D3EFF");
+        byte[]? tocHash = ParserUtils.HashMD5(toc, toc.Length, TOC_HASH_INIT);
 
 
         // Start writing actual file it self.
@@ -304,8 +304,8 @@ internal class SgaV2Parser : ISgaParser
         }
 
         // Calculate the File hash
-        tempStream.Position = 180;
-        byte[]? fileHash = ParserUtils.HashMD5(tempStream, tempStream.Length-tempStream.Position, "E01519D6-2DB7-4640-AF54-0A23319C56C3");
+        tempStream.Position = FILE_HEADER_SIZE;
+        byte[]? fileHash = ParserUtils.HashMD5(tempStream, tempStream.Length-tempStream.Position, FILE_HASH_INIT);
         
         // Write the file hash
         tempStream.Position = 12;
@@ -316,43 +316,6 @@ internal class SgaV2Parser : ISgaParser
         tempStream.Position = 0;
         tempStream.CopyTo(sgaStream);
         sgaStream.SetLength(sgaStream.Position);
-    }
-
-    // Mock logging. For testing only. this will be replaces when i will be finished with writer.
-    private static void LogArchive(SgaArchive archive)
-    {
-        Console.WriteLine("Archive name: {0}",archive.ArchiveName);
-        Console.WriteLine("Drives:");
-
-        foreach (var drive in archive.Drives)
-        {
-            Console.WriteLine("    Drive name: {0}", drive.Name);
-            Console.WriteLine("    Drive alias: {0}", drive.Alias);
-
-            Stack<Tuple<SgaEntry, int>> stack = new Stack<Tuple<SgaEntry, int>>();
-            stack.Push(new Tuple<SgaEntry, int>(drive.RootFolder,0));
-
-            while(stack.Count > 0)
-            {
-                var item = stack.Pop();
-                SgaEntry entry = item.Item1;
-
-                if (entry is SgaFile file)
-                {
-                    Console.WriteLine(new string(' ', item.Item2 *2) + $"    File: {file.Name}");
-                    //file.Open();
-                }
-                else if (entry is SgaFolder folder)
-                {
-                    Console.WriteLine(new string(' ', item.Item2 *2) + $"    Folder: {folder.Name}");
-                    // Push subentries onto the stack
-                    for (int i = folder.Contents.Count - 1; i >= 0; i--) // reverse to maintain order
-                    {
-                        stack.Push(new Tuple<SgaEntry, int>(folder.Contents[i], item.Item2 + 1));
-                    }
-                }
-            }
-        }
     }
 
     private static StorageType ReadStorageType(Stream sgaStream, bool isIC)

--- a/OpenCompote/Parsers/SgaV2Parser.cs
+++ b/OpenCompote/Parsers/SgaV2Parser.cs
@@ -1,11 +1,34 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Net.Mime;
 using OpenCompote.SGA.Parsers.Structs;
 
 namespace OpenCompote.SGA.Parsers;
 
+internal struct DriveTest(SgaDrive drive)
+{
+    public SgaDrive Drive { get; set; } = drive;
+    public ushort FirstFolder {get; set;}
+    public ushort LastFolder {get; set;}
+    public ushort FirstFile {get; set;}
+    public ushort LastFile {get; set;}
+}
+
+internal struct FolderTest(SgaFolder folder)
+{
+    public SgaFolder folder { get; set; } = folder;
+    public ushort FirstFolder {get; set;}
+    public ushort LastFolder {get; set;}
+    public ushort FirstFile {get; set;}
+    public ushort LastFile {get; set;}
+}
+
 internal class SgaV2Parser : ISgaParser
 {
+    private const int DRIVE_SIZE = 0;
+    private const int FOLDER_SIZE = 0;
+    private const int FILE_SIZE = 0;
+
     public void Parse(SgaArchive archive, Stream sgaStream)
     {
         List<DriveRecord> driveList = new List<DriveRecord>();
@@ -28,6 +51,13 @@ internal class SgaV2Parser : ISgaParser
         byte[]? generatedTocHash = ParserUtils.HashMD5(sgaStream, tocSize, "DFC9AF62-FC1B-4180-BC27-11CCE87D3EFF");
         if(generatedTocHash == null || !tocHash.SequenceEqual(generatedTocHash))
             Console.WriteLine("Hash is  not valid");
+
+        // var curPosition = sgaStream.Position;
+        // using var tempStream = new FileStream("toc.bin", FileMode.Create, FileAccess.Write);
+        // byte[] buffer = new byte[tocSize];
+        // sgaStream.ReadExactly(buffer);
+        // sgaStream.Position = curPosition;
+        // tempStream.Write(buffer);
 
         // Read TOC header
         uint driveOffset = ParserUtils.ReadUInt32(sgaStream);
@@ -131,21 +161,30 @@ internal class SgaV2Parser : ISgaParser
     public void Write(SgaArchive archive, Stream sgaStream)
     {
         // Currently writing directly into specific file. Only for testing. The final implementation will not use hardcoded paths.
-        //using var tempStream = new FileStream("output.bin", FileMode.Create, FileAccess.Write);
+        using var tempStream = new FileStream("output.bin", FileMode.Create, FileAccess.Write);
         //LogArchive(archive);  
 
         // Build TOC and Data block in-memory, then write header + TOC + Data to `sgaStream`.
-        List<SgaDrive> drives = archive._drives;
+        List<DriveTest> driveList = new List<DriveTest>();
 
         // Flatten folders and files per-drive so that folder/file indices are contiguous per-drive
         List<SgaFolder> folderList = new List<SgaFolder>();
         List<SgaFile> fileList = new List<SgaFile>();
+        List<string> nameList = new List<string>();
+
+        // For mapping names to offsets later
+        List<uint> folderNameOffsets = new List<uint>();
+        List<uint> fileNameOffsets = new List<uint>();
 
         // We'll traverse drives in order and append their folder trees
-        foreach (var drive in drives)
+        foreach (var drive in archive._drives)
         {
             // iterative preorder traversal to produce folderList
             var stack = new Stack<SgaFolder>();
+            var driveTest = new DriveTest(drive);
+            driveTest.FirstFolder = (ushort)folderList.Count;
+            driveTest.FirstFile = (ushort)fileList.Count;
+
             if (drive.RootFolder != null)
             {
                 stack.Push(drive.RootFolder);
@@ -156,6 +195,10 @@ internal class SgaV2Parser : ISgaParser
             {
                 var f = stack.Pop();
 
+                // Add folder name to name list (we'll fill offsets later)
+                nameList.Add(f.Name ?? string.Empty);
+                folderNameOffsets.Add(0);
+
                 // Add files of this folder (collect now but add their names later)
                 foreach (var e in f.Contents)
                 {
@@ -163,6 +206,8 @@ internal class SgaV2Parser : ISgaParser
                     {
                         // record file will be appended to fileList, but we also need to keep mapping for names
                         fileList.Add(sf);
+                        nameList.Add(sf.Name ?? string.Empty);
+                        fileNameOffsets.Add(0);
                     }
 
                     if (e is SgaFolder child)
@@ -175,7 +220,287 @@ internal class SgaV2Parser : ISgaParser
                         stack.Push(child);
                 }
             }
+
+            driveTest.LastFolder = (ushort)folderList.Count;
+            driveTest.LastFile = (ushort)fileList.Count;
+            driveList.Add(driveTest);
         }
+
+        
+        using var toc = new MemoryStream();
+
+        uint folderOffset = (uint)(24 + driveList.Count * DRIVE_SIZE);
+        uint fileOffset = folderOffset + (uint)folderList.Count * FOLDER_SIZE;
+        uint nameOffset = fileOffset + (uint)fileList.Count * FILE_SIZE;
+
+        ParserUtils.WriteUInt32(toc, 24);                               // Drive offset
+        ParserUtils.WriteUInt16(toc, (ushort)driveList.Count);          // Drive count
+        ParserUtils.WriteUInt32(toc, folderOffset);                     // Folder offset
+        ParserUtils.WriteUInt16(toc, (ushort)folderList.Count);         // Folder count
+        ParserUtils.WriteUInt32(toc, fileOffset);                       // File offset
+        ParserUtils.WriteUInt16(toc, (ushort)fileList.Count);           // File count        
+        ParserUtils.WriteUInt32(toc, nameOffset);                       // Name offset
+        ParserUtils.WriteUInt16(toc, (ushort)(folderList.Count + fileList.Count)); // Name count
+
+        // Write drives
+        foreach (var drive in driveList)
+        {
+            ParserUtils.WriteStaticString(toc, drive.Drive.Alias, 64);
+            ParserUtils.WriteStaticString(toc, drive.Drive.Name, 64);
+            ParserUtils.WriteUInt16(toc, drive.FirstFolder);
+            ParserUtils.WriteUInt16(toc, drive.LastFolder);
+            ParserUtils.WriteUInt16(toc, drive.FirstFile);
+            ParserUtils.WriteUInt16(toc, drive.LastFile);
+            ParserUtils.WriteUInt16(toc, 0);
+        }
+
+        ushort folderIndex = 1;
+        ushort fileIndex = 0;
+
+        foreach (var f in folderList)
+        {
+            ushort fileCount = (ushort)f.Contents.Count((item)=>{return item is SgaFile;});
+            ushort folderCount = (ushort)f.Contents.Count((item)=>{return item is SgaFolder;});
+            fileCount += fileIndex;
+            folderCount += folderIndex;
+
+            ParserUtils.WriteUInt32(toc, 0);
+            ParserUtils.WriteUInt16(toc, folderIndex);
+            ParserUtils.WriteUInt16(toc, folderCount);
+            ParserUtils.WriteUInt16(toc, fileIndex);
+            ParserUtils.WriteUInt16(toc, fileCount);
+
+            folderIndex = folderCount;
+            fileIndex = fileCount;
+        }
+
+        // Write file records placeholders (nameOffset, storageFlag, dataOffset, compressedSize, decompressedSize)
+        foreach (var f in fileList)
+        {
+            using var contents = f.Open();
+            uint size = (uint)contents.Length;
+
+            ParserUtils.WriteUInt32(toc, 0);
+            ParserUtils.WriteUInt32(toc, (uint)StorageType.Uncompress);
+            ParserUtils.WriteUInt32(toc, 0);
+            ParserUtils.WriteUInt32(toc, size);
+            ParserUtils.WriteUInt32(toc, size);
+        }
+
+        /*long nameListStart = toc.Position;
+        // Write name list
+        foreach (var nb in nameBytesList)
+            toc.Write(nb, 0, nb.Length);
+
+        long tocSize = toc.Length;
+
+        // Now compute data block offsets: dataBlock starts at 180 + tocSize
+        uint dataOffset = (uint)(180 + tocSize);
+
+        // Build data block into another MemoryStream and compute per-file data offsets and sizes
+        using var dataBlock = new MemoryStream();
+        using var dbw = new BinaryWriter(dataBlock, System.Text.Encoding.ASCII, true);
+
+        // We'll collect file metadata: for each file write 256-byte name (padded), 4-byte modified, 4-byte CRC, then file bytes
+        var fileRawOffsets = new List<uint>();
+        var fileCompressedSizes = new List<uint>();
+        var fileDecompressedSizes = new List<uint>();
+
+        foreach (var f in fileList)
+        {
+            // record offset to start of compressed data (i.e., after metadata)
+            uint rawOffset = (uint)dataBlock.Position + 264; // metadata length is 264 bytes
+            fileRawOffsets.Add(rawOffset);
+
+            // write metadata: 256-byte filename (ASCII, zero padded)
+            var nameBytes = System.Text.Encoding.ASCII.GetBytes(f.Name ?? string.Empty);
+            var nameBuf = new byte[256];
+            Array.Clear(nameBuf, 0, nameBuf.Length);
+            Array.Copy(nameBytes, nameBuf, Math.Min(nameBytes.Length, 256));
+            dbw.Write(nameBuf);
+            // write modified (placeholder 0)
+            dbw.Write((uint)0);
+            // write CRC placeholder (0)
+            dbw.Write((uint)0);
+
+            // Write file data (uncompressed)
+            long dataStart = dataBlock.Position;
+            // If SgaFile has a method to open stream, use it; otherwise assume we can access underlying bytes via Open() or Data property
+            try
+            {
+                using var fs = f.Open();
+                fs.Seek(0, SeekOrigin.Begin);
+                fs.CopyTo(dataBlock);
+            }
+            catch
+            {
+                // If opening fails, write zero-length
+            }
+
+            uint compressedSize = (uint)(dataBlock.Position - dataStart);
+            fileCompressedSizes.Add(compressedSize);
+            fileDecompressedSizes.Add(compressedSize);
+        }
+
+        // Now go back and fill header and record placeholders
+        // Fill header fields in toc stream
+        bw.Seek(0, SeekOrigin.Begin);
+        bw.Write((uint)24);
+        bw.Write((ushort)drives.Count);
+        bw.Write((uint)(foldersStart));
+        bw.Write((ushort)folderCount);
+        bw.Write((uint)(filesStart));
+        bw.Write((ushort)fileCount);
+        bw.Write((uint)(nameListStart));
+        bw.Write((ushort)nameBytesList.Count);
+
+        // Fill drive records: compute per-drive folder/file ranges
+        long curFolderIndex = 0;
+        long curFileIndex = 0;
+        bw.Seek((int)drivesStart, SeekOrigin.Begin);
+        foreach (var drive in drives)
+        {
+            // drive alias and name have already been written; skip them to write the indices
+            bw.Seek(64, SeekOrigin.Current);
+            bw.Seek(64, SeekOrigin.Current);
+
+            ushort firstFolder = (ushort)curFolderIndex;
+            // count folders belonging to this drive: walk its subtree
+            int foldersForDrive = 0;
+            if (drive.RootFolder != null)
+            {
+                // count nodes in subtree
+                var stack2 = new Stack<SgaFolder>();
+                stack2.Push(drive.RootFolder);
+                while (stack2.Count > 0)
+                {
+                    var n = stack2.Pop();
+                    foldersForDrive++;
+                    foreach (var c in n.Contents)
+                        if (c is SgaFolder cf)
+                            stack2.Push(cf);
+                }
+            }
+
+            ushort lastFolder = (ushort)(curFolderIndex + foldersForDrive);
+            ushort firstFile = (ushort)curFileIndex;
+
+            // count files in drive
+            int filesForDrive = 0;
+            if (drive.RootFolder != null)
+            {
+                var stack3 = new Stack<SgaFolder>();
+                stack3.Push(drive.RootFolder);
+                while (stack3.Count > 0)
+                {
+                    var n = stack3.Pop();
+                    foreach (var c in n.Contents)
+                        if (c is SgaFile ff)
+                            filesForDrive++;
+                        else if (c is SgaFolder cf)
+                            stack3.Push(cf);
+                }
+            }
+
+            ushort lastFile = (ushort)(curFileIndex + filesForDrive);
+            ushort rootFolderIndex = (ushort)curFolderIndex;
+
+            bw.Write(firstFolder);
+            bw.Write(lastFolder);
+            bw.Write(firstFile);
+            bw.Write(lastFile);
+            bw.Write(rootFolderIndex);
+
+            curFolderIndex += foldersForDrive;
+            curFileIndex += filesForDrive;
+        }
+
+        // Fill folder records
+        bw.Seek((int)foldersStart, SeekOrigin.Begin);
+        // Build a dictionary folder -> index
+        var folderIndexMap = new Dictionary<SgaFolder, int>();
+        for (int i = 0; i < folderList.Count; i++)
+            folderIndexMap[folderList[i]] = i;
+
+        // Build file index map
+        var fileIndexMap = new Dictionary<SgaFile, int>();
+        for (int i = 0; i < fileList.Count; i++)
+            fileIndexMap[fileList[i]] = i;
+
+        for (int i = 0; i < folderList.Count; i++)
+        {
+            var f = folderList[i];
+            uint nameOffset = folderNameOffsets[i];
+
+            // find child folder indices
+            int firstChild = -1;
+            int lastChild = -1;
+            foreach (var c in f.Contents)
+            {
+                if (c is SgaFolder cf)
+                {
+                    int idx = folderIndexMap[cf];
+                    if (firstChild == -1) firstChild = idx;
+                    lastChild = idx;
+                }
+            }
+            ushort firstFolder = firstChild == -1 ? (ushort)0 : (ushort)firstChild;
+            ushort lastFolder = firstChild == -1 ? (ushort)0 : (ushort)(lastChild + 1);
+
+            // files
+            int firstF = -1;
+            int lastF = -1;
+            foreach (var c in f.Contents)
+            {
+                if (c is SgaFile cf)
+                {
+                    int idx = fileIndexMap[cf];
+                    if (firstF == -1) firstF = idx;
+                    lastF = idx;
+                }
+            }
+            ushort firstFileIdx = firstF == -1 ? (ushort)0 : (ushort)firstF;
+            ushort lastFileIdx = firstF == -1 ? (ushort)0 : (ushort)(lastF + 1);
+
+            ParserUtils.WriteUInt32(toc, nameOffset);
+            ParserUtils.WriteUInt16(toc, firstFolder);
+            ParserUtils.WriteUInt16(toc, lastFolder);
+            ParserUtils.WriteUInt16(toc, firstFileIdx);
+            ParserUtils.WriteUInt16(toc, lastFileIdx);
+        }
+
+        // Fill file records
+        bw.Seek((int)filesStart, SeekOrigin.Begin);
+        for (int i = 0; i < fileList.Count; i++)
+        {
+            var f = fileList[i];
+            ParserUtils.WriteUInt32(toc, fileNameOffsets[i]);
+            ParserUtils.WriteUInt32(toc, (uint)StorageType.Uncompress);
+            // raw data offset relative to data block start
+            ParserUtils.WriteUInt32(toc, fileRawOffsets[i]);
+            ParserUtils.WriteUInt32(toc, fileCompressedSizes[i]);
+            ParserUtils.WriteUInt32(toc, fileDecompressedSizes[i]);
+        }
+
+        // Finally write header + toc + dataBlock into provided stream
+        // Header (180 bytes total): magic(8), version(4), fileHash(16), archiveName(128), tocHash(16), tocSize(4), dataOffset(4)
+        // We'll leave hashes zeroed for now
+        ParserUtils.WriteStaticString(sgaStream, "ARCHIVE_", 8);
+        ParserUtils.WriteUInt32(sgaStream, 2);
+        byte[] zeroHash = new byte[16];
+        sgaStream.Write(zeroHash);
+        ParserUtils.WriteWideStaticString(sgaStream, archive.ArchiveName ?? string.Empty, 128);
+        sgaStream.Write(zeroHash);
+        ParserUtils.WriteUInt32(sgaStream, (uint)tocSize);
+        ParserUtils.WriteUInt32(sgaStream, dataOffset);*/
+
+        // write TOC
+        toc.Seek(0, SeekOrigin.Begin);
+        toc.CopyTo(tempStream);
+
+        // write data block
+        //dataBlock.Seek(0, SeekOrigin.Begin);
+        //dataBlock.CopyTo(sgaStream);
     }
 
     // Mock implementation. For testing only. Will be replaces by actual implementation when i will be satisfied by the public interface.

--- a/OpenCompote/Parsers/SgaV2Parser.cs
+++ b/OpenCompote/Parsers/SgaV2Parser.cs
@@ -14,20 +14,11 @@ internal struct DriveTest(SgaDrive drive)
     public ushort LastFile {get; set;}
 }
 
-internal struct FolderTest(SgaFolder folder)
-{
-    public SgaFolder folder { get; set; } = folder;
-    public ushort FirstFolder {get; set;}
-    public ushort LastFolder {get; set;}
-    public ushort FirstFile {get; set;}
-    public ushort LastFile {get; set;}
-}
-
 internal class SgaV2Parser : ISgaParser
 {
-    private const int DRIVE_SIZE = 0;
-    private const int FOLDER_SIZE = 0;
-    private const int FILE_SIZE = 0;
+    private const int DRIVE_SIZE = 138;
+    private const int FOLDER_SIZE = 12;
+    private const int FILE_SIZE = 20;
 
     public void Parse(SgaArchive archive, Stream sgaStream)
     {
@@ -162,7 +153,7 @@ internal class SgaV2Parser : ISgaParser
     {
         // Currently writing directly into specific file. Only for testing. The final implementation will not use hardcoded paths.
         using var tempStream = new FileStream("output.bin", FileMode.Create, FileAccess.Write);
-        //LogArchive(archive);  
+        LogArchive(archive);  
 
         // Build TOC and Data block in-memory, then write header + TOC + Data to `sgaStream`.
         List<DriveTest> driveList = new List<DriveTest>();
@@ -228,7 +219,8 @@ internal class SgaV2Parser : ISgaParser
 
         
         using var toc = new MemoryStream();
-
+        using var nameBuffer = new MemoryStream();
+        
         uint folderOffset = (uint)(24 + driveList.Count * DRIVE_SIZE);
         uint fileOffset = folderOffset + (uint)folderList.Count * FOLDER_SIZE;
         uint nameOffset = fileOffset + (uint)fileList.Count * FILE_SIZE;
@@ -245,8 +237,8 @@ internal class SgaV2Parser : ISgaParser
         // Write drives
         foreach (var drive in driveList)
         {
-            ParserUtils.WriteStaticString(toc, drive.Drive.Alias, 64);
             ParserUtils.WriteStaticString(toc, drive.Drive.Name, 64);
+            ParserUtils.WriteStaticString(toc, drive.Drive.Alias, 64);
             ParserUtils.WriteUInt16(toc, drive.FirstFolder);
             ParserUtils.WriteUInt16(toc, drive.LastFolder);
             ParserUtils.WriteUInt16(toc, drive.FirstFile);
@@ -263,8 +255,10 @@ internal class SgaV2Parser : ISgaParser
             ushort folderCount = (ushort)f.Contents.Count((item)=>{return item is SgaFolder;});
             fileCount += fileIndex;
             folderCount += folderIndex;
+            uint folderNameOffset = (uint)nameBuffer.Position;
+            ParserUtils.WriteDynamicString(nameBuffer, f.Name);
 
-            ParserUtils.WriteUInt32(toc, 0);
+            ParserUtils.WriteUInt32(toc, folderNameOffset);
             ParserUtils.WriteUInt16(toc, folderIndex);
             ParserUtils.WriteUInt16(toc, folderCount);
             ParserUtils.WriteUInt16(toc, fileIndex);
@@ -274,227 +268,25 @@ internal class SgaV2Parser : ISgaParser
             fileIndex = fileCount;
         }
 
+        uint dataOffset = 0;
         // Write file records placeholders (nameOffset, storageFlag, dataOffset, compressedSize, decompressedSize)
         foreach (var f in fileList)
         {
-            using var contents = f.Open();
-            uint size = (uint)contents.Length;
+            uint folderNameOffset = (uint)nameBuffer.Position;
+            ParserUtils.WriteDynamicString(nameBuffer, f.Name);
 
-            ParserUtils.WriteUInt32(toc, 0);
-            ParserUtils.WriteUInt32(toc, (uint)StorageType.Uncompress);
-            ParserUtils.WriteUInt32(toc, 0);
-            ParserUtils.WriteUInt32(toc, size);
-            ParserUtils.WriteUInt32(toc, size);
+            ParserUtils.WriteUInt32(toc, folderNameOffset);
+            ParserUtils.WriteUInt32(toc, WriteStorageType(f.StorageType));
+            ParserUtils.WriteUInt32(toc, dataOffset);
+            ParserUtils.WriteUInt32(toc, f.Size);
+            ParserUtils.WriteUInt32(toc, f.CompressedSize);
+
+            dataOffset += f.CompressedSize;
         }
-
-        /*long nameListStart = toc.Position;
-        // Write name list
-        foreach (var nb in nameBytesList)
-            toc.Write(nb, 0, nb.Length);
-
-        long tocSize = toc.Length;
-
-        // Now compute data block offsets: dataBlock starts at 180 + tocSize
-        uint dataOffset = (uint)(180 + tocSize);
-
-        // Build data block into another MemoryStream and compute per-file data offsets and sizes
-        using var dataBlock = new MemoryStream();
-        using var dbw = new BinaryWriter(dataBlock, System.Text.Encoding.ASCII, true);
-
-        // We'll collect file metadata: for each file write 256-byte name (padded), 4-byte modified, 4-byte CRC, then file bytes
-        var fileRawOffsets = new List<uint>();
-        var fileCompressedSizes = new List<uint>();
-        var fileDecompressedSizes = new List<uint>();
-
-        foreach (var f in fileList)
-        {
-            // record offset to start of compressed data (i.e., after metadata)
-            uint rawOffset = (uint)dataBlock.Position + 264; // metadata length is 264 bytes
-            fileRawOffsets.Add(rawOffset);
-
-            // write metadata: 256-byte filename (ASCII, zero padded)
-            var nameBytes = System.Text.Encoding.ASCII.GetBytes(f.Name ?? string.Empty);
-            var nameBuf = new byte[256];
-            Array.Clear(nameBuf, 0, nameBuf.Length);
-            Array.Copy(nameBytes, nameBuf, Math.Min(nameBytes.Length, 256));
-            dbw.Write(nameBuf);
-            // write modified (placeholder 0)
-            dbw.Write((uint)0);
-            // write CRC placeholder (0)
-            dbw.Write((uint)0);
-
-            // Write file data (uncompressed)
-            long dataStart = dataBlock.Position;
-            // If SgaFile has a method to open stream, use it; otherwise assume we can access underlying bytes via Open() or Data property
-            try
-            {
-                using var fs = f.Open();
-                fs.Seek(0, SeekOrigin.Begin);
-                fs.CopyTo(dataBlock);
-            }
-            catch
-            {
-                // If opening fails, write zero-length
-            }
-
-            uint compressedSize = (uint)(dataBlock.Position - dataStart);
-            fileCompressedSizes.Add(compressedSize);
-            fileDecompressedSizes.Add(compressedSize);
-        }
-
-        // Now go back and fill header and record placeholders
-        // Fill header fields in toc stream
-        bw.Seek(0, SeekOrigin.Begin);
-        bw.Write((uint)24);
-        bw.Write((ushort)drives.Count);
-        bw.Write((uint)(foldersStart));
-        bw.Write((ushort)folderCount);
-        bw.Write((uint)(filesStart));
-        bw.Write((ushort)fileCount);
-        bw.Write((uint)(nameListStart));
-        bw.Write((ushort)nameBytesList.Count);
-
-        // Fill drive records: compute per-drive folder/file ranges
-        long curFolderIndex = 0;
-        long curFileIndex = 0;
-        bw.Seek((int)drivesStart, SeekOrigin.Begin);
-        foreach (var drive in drives)
-        {
-            // drive alias and name have already been written; skip them to write the indices
-            bw.Seek(64, SeekOrigin.Current);
-            bw.Seek(64, SeekOrigin.Current);
-
-            ushort firstFolder = (ushort)curFolderIndex;
-            // count folders belonging to this drive: walk its subtree
-            int foldersForDrive = 0;
-            if (drive.RootFolder != null)
-            {
-                // count nodes in subtree
-                var stack2 = new Stack<SgaFolder>();
-                stack2.Push(drive.RootFolder);
-                while (stack2.Count > 0)
-                {
-                    var n = stack2.Pop();
-                    foldersForDrive++;
-                    foreach (var c in n.Contents)
-                        if (c is SgaFolder cf)
-                            stack2.Push(cf);
-                }
-            }
-
-            ushort lastFolder = (ushort)(curFolderIndex + foldersForDrive);
-            ushort firstFile = (ushort)curFileIndex;
-
-            // count files in drive
-            int filesForDrive = 0;
-            if (drive.RootFolder != null)
-            {
-                var stack3 = new Stack<SgaFolder>();
-                stack3.Push(drive.RootFolder);
-                while (stack3.Count > 0)
-                {
-                    var n = stack3.Pop();
-                    foreach (var c in n.Contents)
-                        if (c is SgaFile ff)
-                            filesForDrive++;
-                        else if (c is SgaFolder cf)
-                            stack3.Push(cf);
-                }
-            }
-
-            ushort lastFile = (ushort)(curFileIndex + filesForDrive);
-            ushort rootFolderIndex = (ushort)curFolderIndex;
-
-            bw.Write(firstFolder);
-            bw.Write(lastFolder);
-            bw.Write(firstFile);
-            bw.Write(lastFile);
-            bw.Write(rootFolderIndex);
-
-            curFolderIndex += foldersForDrive;
-            curFileIndex += filesForDrive;
-        }
-
-        // Fill folder records
-        bw.Seek((int)foldersStart, SeekOrigin.Begin);
-        // Build a dictionary folder -> index
-        var folderIndexMap = new Dictionary<SgaFolder, int>();
-        for (int i = 0; i < folderList.Count; i++)
-            folderIndexMap[folderList[i]] = i;
-
-        // Build file index map
-        var fileIndexMap = new Dictionary<SgaFile, int>();
-        for (int i = 0; i < fileList.Count; i++)
-            fileIndexMap[fileList[i]] = i;
-
-        for (int i = 0; i < folderList.Count; i++)
-        {
-            var f = folderList[i];
-            uint nameOffset = folderNameOffsets[i];
-
-            // find child folder indices
-            int firstChild = -1;
-            int lastChild = -1;
-            foreach (var c in f.Contents)
-            {
-                if (c is SgaFolder cf)
-                {
-                    int idx = folderIndexMap[cf];
-                    if (firstChild == -1) firstChild = idx;
-                    lastChild = idx;
-                }
-            }
-            ushort firstFolder = firstChild == -1 ? (ushort)0 : (ushort)firstChild;
-            ushort lastFolder = firstChild == -1 ? (ushort)0 : (ushort)(lastChild + 1);
-
-            // files
-            int firstF = -1;
-            int lastF = -1;
-            foreach (var c in f.Contents)
-            {
-                if (c is SgaFile cf)
-                {
-                    int idx = fileIndexMap[cf];
-                    if (firstF == -1) firstF = idx;
-                    lastF = idx;
-                }
-            }
-            ushort firstFileIdx = firstF == -1 ? (ushort)0 : (ushort)firstF;
-            ushort lastFileIdx = firstF == -1 ? (ushort)0 : (ushort)(lastF + 1);
-
-            ParserUtils.WriteUInt32(toc, nameOffset);
-            ParserUtils.WriteUInt16(toc, firstFolder);
-            ParserUtils.WriteUInt16(toc, lastFolder);
-            ParserUtils.WriteUInt16(toc, firstFileIdx);
-            ParserUtils.WriteUInt16(toc, lastFileIdx);
-        }
-
-        // Fill file records
-        bw.Seek((int)filesStart, SeekOrigin.Begin);
-        for (int i = 0; i < fileList.Count; i++)
-        {
-            var f = fileList[i];
-            ParserUtils.WriteUInt32(toc, fileNameOffsets[i]);
-            ParserUtils.WriteUInt32(toc, (uint)StorageType.Uncompress);
-            // raw data offset relative to data block start
-            ParserUtils.WriteUInt32(toc, fileRawOffsets[i]);
-            ParserUtils.WriteUInt32(toc, fileCompressedSizes[i]);
-            ParserUtils.WriteUInt32(toc, fileDecompressedSizes[i]);
-        }
-
-        // Finally write header + toc + dataBlock into provided stream
-        // Header (180 bytes total): magic(8), version(4), fileHash(16), archiveName(128), tocHash(16), tocSize(4), dataOffset(4)
-        // We'll leave hashes zeroed for now
-        ParserUtils.WriteStaticString(sgaStream, "ARCHIVE_", 8);
-        ParserUtils.WriteUInt32(sgaStream, 2);
-        byte[] zeroHash = new byte[16];
-        sgaStream.Write(zeroHash);
-        ParserUtils.WriteWideStaticString(sgaStream, archive.ArchiveName ?? string.Empty, 128);
-        sgaStream.Write(zeroHash);
-        ParserUtils.WriteUInt32(sgaStream, (uint)tocSize);
-        ParserUtils.WriteUInt32(sgaStream, dataOffset);*/
 
         // write TOC
+        nameBuffer.Seek(0, SeekOrigin.Begin);
+        nameBuffer.CopyTo(toc);
         toc.Seek(0, SeekOrigin.Begin);
         toc.CopyTo(tempStream);
 
@@ -560,6 +352,16 @@ internal class SgaV2Parser : ISgaParser
             0 => StorageType.Uncompress,
             16 => StorageType.BufferCompress,
             32 => StorageType.StreamCompress,
+            _ => throw new Exception("Invalid storage flag value."),
+        };
+    }
+
+    private static uint WriteStorageType(StorageType type){
+        return type switch
+        {
+            StorageType.Uncompress => 0,
+            StorageType.BufferCompress => 16,
+            StorageType.StreamCompress => 32,
             _ => throw new Exception("Invalid storage flag value."),
         };
     }

--- a/OpenCompote/Parsers/SgaV2Parser.cs
+++ b/OpenCompote/Parsers/SgaV2Parser.cs
@@ -69,7 +69,7 @@ internal class SgaV2Parser : ISgaParser
         uint nameListOffset = ParserUtils.ReadUInt32(sgaStream);
         ushort nameCount = ParserUtils.ReadUInt16(sgaStream);
 
-        bool isIc =  (nameListOffset - fileOffset)/fileCount == 17;
+        bool isIc = fileCount != 0 && (nameListOffset - fileOffset)/fileCount == 17;
 
         // Read drive definitions
         for (int i = 0; i < driveCount; i++)
@@ -168,6 +168,7 @@ internal class SgaV2Parser : ISgaParser
     {
         // Currently writing directly into specific file. Only for testing. The final implementation will not use hardcoded paths.
         //using var tempStream = new FileStream("output.bin", FileMode.Create, FileAccess.Write); 
+        LogArchive(archive);
         using var tempStream = new MemoryStream();
 
         // Flatten drives folders and files so that folder/file indices are contiguous per-drive
@@ -253,7 +254,7 @@ internal class SgaV2Parser : ISgaParser
             ParserUtils.WriteUInt16(toc, drive.LastFolder);
             ParserUtils.WriteUInt16(toc, drive.FirstFile);
             ParserUtils.WriteUInt16(toc, drive.LastFile);
-            ParserUtils.WriteUInt16(toc, 0);
+            ParserUtils.WriteUInt16(toc, drive.FirstFolder);
         }
 
         foreach (var f in folderList)
@@ -310,7 +311,7 @@ internal class SgaV2Parser : ISgaParser
         foreach(var file in fileList)
         {
             tempStream.Write(emptyMetaData);
-            using var contents = file.GetExactStream();
+            using var contents = file.GetResultStream();
             contents.CopyTo(tempStream);
         }
 

--- a/OpenCompote/Parsers/SgaV2Parser.cs
+++ b/OpenCompote/Parsers/SgaV2Parser.cs
@@ -129,7 +129,26 @@ internal class SgaV2Parser : ISgaParser
 
     public void Write(SgaArchive archive, Stream sgaStream)
     {
-        // Mock implementation. For testing only. Will be replaces by actual implementation when i will be satisfied by the public interface.
+        // Currently writing directly into specific file. Only for testing. The final implementation will not use hardcoded paths.
+        using var tempStream = new FileStream("output.bin", FileMode.Create, FileAccess.Write);
+        //LogArchive(archive);   
+
+        ParserUtils.WriteStaticString(tempStream,"_ARCHIVE", 8);
+        ParserUtils.WriteUInt32(tempStream, 2);
+
+        byte[] MockHash = new byte[16];
+        tempStream.Write(MockHash);
+        ParserUtils.WriteWideStaticString(tempStream, "W40kDataKeys", 128);
+        tempStream.Write(MockHash);
+        ParserUtils.WriteUInt32(tempStream, 0);
+        ParserUtils.WriteUInt32(tempStream, 0);
+        ParserUtils.WriteDynamicString(tempStream, "Hello world this is 0 terminated string!");
+        ParserUtils.WriteDynamicString(tempStream, "This is the second 0 terminated string!");
+    }
+
+    // Mock implementation. For testing only. Will be replaces by actual implementation when i will be satisfied by the public interface.
+    private static void LogArchive(SgaArchive archive)
+    {
         Console.WriteLine("Archive name: {0}",archive.ArchiveName);
         Console.WriteLine("Drives:");
 

--- a/OpenCompote/Parsers/SgaV2Parser.cs
+++ b/OpenCompote/Parsers/SgaV2Parser.cs
@@ -1,6 +1,3 @@
-using System.Collections;
-using System.Diagnostics.CodeAnalysis;
-using System.Net.Mime;
 using OpenCompote.SGA.Parsers.Structs;
 
 namespace OpenCompote.SGA.Parsers;
@@ -8,6 +5,15 @@ namespace OpenCompote.SGA.Parsers;
 internal struct DriveTest(SgaDrive drive)
 {
     public SgaDrive Drive { get; set; } = drive;
+    public ushort FirstFolder {get; set;}
+    public ushort LastFolder {get; set;}
+    public ushort FirstFile {get; set;}
+    public ushort LastFile {get; set;}
+}
+
+internal class FolderTest(SgaFolder folder)
+{
+    public SgaFolder Folder { get; set; } = folder;
     public ushort FirstFolder {get; set;}
     public ushort LastFolder {get; set;}
     public ushort FirstFile {get; set;}
@@ -155,61 +161,56 @@ internal class SgaV2Parser : ISgaParser
         using var tempStream = new FileStream("output.bin", FileMode.Create, FileAccess.Write);
         LogArchive(archive);  
 
-        // Build TOC and Data block in-memory, then write header + TOC + Data to `sgaStream`.
+        // Flatten drives folders and files so that folder/file indices are contiguous per-drive
         List<DriveTest> driveList = new List<DriveTest>();
-
-        // Flatten folders and files per-drive so that folder/file indices are contiguous per-drive
-        List<SgaFolder> folderList = new List<SgaFolder>();
+        List<FolderTest> folderList = new List<FolderTest>();
         List<SgaFile> fileList = new List<SgaFile>();
-        List<string> nameList = new List<string>();
-
-        // For mapping names to offsets later
-        List<uint> folderNameOffsets = new List<uint>();
-        List<uint> fileNameOffsets = new List<uint>();
 
         // We'll traverse drives in order and append their folder trees
         foreach (var drive in archive._drives)
         {
             // iterative preorder traversal to produce folderList
-            var stack = new Stack<SgaFolder>();
+            var stack = new Stack<FolderTest>();
             var driveTest = new DriveTest(drive);
             driveTest.FirstFolder = (ushort)folderList.Count;
             driveTest.FirstFile = (ushort)fileList.Count;
 
             if (drive.RootFolder != null)
             {
-                stack.Push(drive.RootFolder);
-                folderList.Add(drive.RootFolder);
+                FolderTest folderTest = new FolderTest(drive.RootFolder);
+                stack.Push(folderTest);
+                folderList.Add(folderTest);
             }
 
             while (stack.Count > 0)
             {
                 var f = stack.Pop();
-
-                // Add folder name to name list (we'll fill offsets later)
-                nameList.Add(f.Name ?? string.Empty);
-                folderNameOffsets.Add(0);
+                f.FirstFolder = (ushort)folderList.Count;
+                f.FirstFile = (ushort)fileList.Count;
+                var Contents = f.Folder.Contents;
 
                 // Add files of this folder (collect now but add their names later)
-                foreach (var e in f.Contents)
+                foreach (var e in Contents)
                 {
                     if (e is SgaFile sf)
                     {
                         // record file will be appended to fileList, but we also need to keep mapping for names
                         fileList.Add(sf);
-                        nameList.Add(sf.Name ?? string.Empty);
-                        fileNameOffsets.Add(0);
                     }
 
-                    if (e is SgaFolder child)
+                    if (e is SgaFolder childFolder)
+                    {
+                        FolderTest child = new FolderTest(childFolder);
                         folderList.Add(child);
+                    }
                 }
 
-                for(int i = f.Contents.Count-1; i >= 0; i--)
-                {
-                    if (f.Contents[i] is SgaFolder child)
-                        stack.Push(child);
-                }
+                for(int i = folderList.Count-1; i >= f.FirstFolder; i--)
+                    stack.Push(folderList[i]);
+
+                f.LastFolder = (ushort)folderList.Count;
+                f.LastFile = (ushort)fileList.Count;
+                
             }
 
             driveTest.LastFolder = (ushort)folderList.Count;
@@ -246,29 +247,19 @@ internal class SgaV2Parser : ISgaParser
             ParserUtils.WriteUInt16(toc, 0);
         }
 
-        ushort folderIndex = 1;
-        ushort fileIndex = 0;
-
         foreach (var f in folderList)
         {
-            ushort fileCount = (ushort)f.Contents.Count((item)=>{return item is SgaFile;});
-            ushort folderCount = (ushort)f.Contents.Count((item)=>{return item is SgaFolder;});
-            fileCount += fileIndex;
-            folderCount += folderIndex;
             uint folderNameOffset = (uint)nameBuffer.Position;
-            ParserUtils.WriteDynamicString(nameBuffer, f.Name);
+            ParserUtils.WriteDynamicString(nameBuffer, f.Folder.Name);
 
             ParserUtils.WriteUInt32(toc, folderNameOffset);
-            ParserUtils.WriteUInt16(toc, folderIndex);
-            ParserUtils.WriteUInt16(toc, folderCount);
-            ParserUtils.WriteUInt16(toc, fileIndex);
-            ParserUtils.WriteUInt16(toc, fileCount);
-
-            folderIndex = folderCount;
-            fileIndex = fileCount;
+            ParserUtils.WriteUInt16(toc, f.FirstFolder);
+            ParserUtils.WriteUInt16(toc, f.LastFolder);
+            ParserUtils.WriteUInt16(toc, f.FirstFile);
+            ParserUtils.WriteUInt16(toc, f.LastFile);
         }
 
-        uint dataOffset = 0;
+        uint dataOffset = 264;
         // Write file records placeholders (nameOffset, storageFlag, dataOffset, compressedSize, decompressedSize)
         foreach (var f in fileList)
         {
@@ -278,10 +269,10 @@ internal class SgaV2Parser : ISgaParser
             ParserUtils.WriteUInt32(toc, folderNameOffset);
             ParserUtils.WriteUInt32(toc, WriteStorageType(f.StorageType));
             ParserUtils.WriteUInt32(toc, dataOffset);
-            ParserUtils.WriteUInt32(toc, f.Size);
             ParserUtils.WriteUInt32(toc, f.CompressedSize);
+            ParserUtils.WriteUInt32(toc, f.Size);
 
-            dataOffset += f.CompressedSize;
+            dataOffset += f.CompressedSize + 264;
         }
 
         // write TOC

--- a/OpenCompote/Parsers/SgaV2Parser.cs
+++ b/OpenCompote/Parsers/SgaV2Parser.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using OpenCompote.SGA.Parsers.Structs;
 
 namespace OpenCompote.SGA.Parsers;
@@ -85,19 +87,18 @@ internal class SgaV2Parser : ISgaParser
             fileList.Add(file);
         }
 
-
         // build the archive tree 
         foreach (DriveRecord driveRecord in driveList)
         {
             SgaDrive newDrive = new SgaDrive(driveRecord.DriveAlias, driveRecord.DriveName, archive);
             archive._drives.Add(newDrive);
 
-            Stack<Tuple<FolderRecord, SgaFolder?>> stack = new ();
-            stack.Push(new (folderList[driveRecord.RootFolder], null));
+            Queue<Tuple<FolderRecord, SgaFolder?>> stack = new ();
+            stack.Enqueue(new (folderList[driveRecord.RootFolder], null));
 
             while(stack.Count > 0)
             {
-                var item = stack.Pop();
+                var item = stack.Dequeue();
                 FolderRecord currentRecord = item.Item1;
                 SgaFolder? parent = item.Item2;
                 
@@ -113,7 +114,7 @@ internal class SgaV2Parser : ISgaParser
 
                 for (ushort i = currentRecord.FirstFolder; i < currentRecord.LastFolder; i++)
                 {
-                    stack.Push(new(folderList[i], currentFolder));
+                    stack.Enqueue(new(folderList[i], currentFolder));
                 }
 
                 for (ushort i = currentRecord.FirstFile; i < currentRecord.LastFile; i++)
@@ -130,20 +131,51 @@ internal class SgaV2Parser : ISgaParser
     public void Write(SgaArchive archive, Stream sgaStream)
     {
         // Currently writing directly into specific file. Only for testing. The final implementation will not use hardcoded paths.
-        using var tempStream = new FileStream("output.bin", FileMode.Create, FileAccess.Write);
-        //LogArchive(archive);   
+        //using var tempStream = new FileStream("output.bin", FileMode.Create, FileAccess.Write);
+        //LogArchive(archive);  
 
-        ParserUtils.WriteStaticString(tempStream,"_ARCHIVE", 8);
-        ParserUtils.WriteUInt32(tempStream, 2);
+        // Build TOC and Data block in-memory, then write header + TOC + Data to `sgaStream`.
+        List<SgaDrive> drives = archive._drives;
 
-        byte[] MockHash = new byte[16];
-        tempStream.Write(MockHash);
-        ParserUtils.WriteWideStaticString(tempStream, "W40kDataKeys", 128);
-        tempStream.Write(MockHash);
-        ParserUtils.WriteUInt32(tempStream, 0);
-        ParserUtils.WriteUInt32(tempStream, 0);
-        ParserUtils.WriteDynamicString(tempStream, "Hello world this is 0 terminated string!");
-        ParserUtils.WriteDynamicString(tempStream, "This is the second 0 terminated string!");
+        // Flatten folders and files per-drive so that folder/file indices are contiguous per-drive
+        List<SgaFolder> folderList = new List<SgaFolder>();
+        List<SgaFile> fileList = new List<SgaFile>();
+
+        // We'll traverse drives in order and append their folder trees
+        foreach (var drive in drives)
+        {
+            // iterative preorder traversal to produce folderList
+            var stack = new Stack<SgaFolder>();
+            if (drive.RootFolder != null)
+            {
+                stack.Push(drive.RootFolder);
+                folderList.Add(drive.RootFolder);
+            }
+
+            while (stack.Count > 0)
+            {
+                var f = stack.Pop();
+
+                // Add files of this folder (collect now but add their names later)
+                foreach (var e in f.Contents)
+                {
+                    if (e is SgaFile sf)
+                    {
+                        // record file will be appended to fileList, but we also need to keep mapping for names
+                        fileList.Add(sf);
+                    }
+
+                    if (e is SgaFolder child)
+                        folderList.Add(child);
+                }
+
+                for(int i = f.Contents.Count-1; i >= 0; i--)
+                {
+                    if (f.Contents[i] is SgaFolder child)
+                        stack.Push(child);
+                }
+            }
+        }
     }
 
     // Mock implementation. For testing only. Will be replaces by actual implementation when i will be satisfied by the public interface.

--- a/OpenCompote/Parsers/SgaV2Parser.cs
+++ b/OpenCompote/Parsers/SgaV2Parser.cs
@@ -1,3 +1,6 @@
+using System.ComponentModel.Design;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
 using OpenCompote.SGA.Parsers.Structs;
 
 namespace OpenCompote.SGA.Parsers;
@@ -278,8 +281,41 @@ internal class SgaV2Parser : ISgaParser
         // write TOC
         nameBuffer.Seek(0, SeekOrigin.Begin);
         nameBuffer.CopyTo(toc);
+
+        ParserUtils.WriteStaticString(tempStream, "_ARCHIVE", 8);
+        ParserUtils.WriteUInt32(tempStream, (uint)archive.Version);
+        
+        byte[] emptyHash = new byte[16];
+        tempStream.Write(emptyHash);
+        
+        ParserUtils.WriteWideStaticString(tempStream, archive.ArchiveName, 128);
+        
+        tempStream.Write(emptyHash);
+        
+        ParserUtils.WriteUInt32(tempStream, (uint)toc.Position);
+        ParserUtils.WriteUInt32(tempStream, (uint)(toc.Position + 180 ));
+        
         toc.Seek(0, SeekOrigin.Begin);
         toc.CopyTo(tempStream);
+
+        byte[] emptyMetaData = new byte[264];
+
+        foreach(var file in fileList)
+        {
+            using var contents = file.Open();
+
+            tempStream.Write(emptyMetaData);
+
+            if(file.StorageType == StorageType.Uncompress)
+            {
+                contents.CopyTo(tempStream);
+            }
+            else
+            {
+                using var compressed = new ZLibStream(tempStream, CompressionMode.Compress, true);
+                contents.CopyTo(compressed);
+            }
+        }
 
         // write data block
         //dataBlock.Seek(0, SeekOrigin.Begin);

--- a/OpenCompote/Parsers/SgaV2Parser.cs
+++ b/OpenCompote/Parsers/SgaV2Parser.cs
@@ -161,8 +161,8 @@ internal class SgaV2Parser : ISgaParser
     public void Write(SgaArchive archive, Stream sgaStream)
     {
         // Currently writing directly into specific file. Only for testing. The final implementation will not use hardcoded paths.
-        using var tempStream = new FileStream("output.bin", FileMode.Create, FileAccess.Write);
-        LogArchive(archive);  
+        //using var tempStream = new FileStream("output.bin", FileMode.Create, FileAccess.Write); 
+        using var tempStream = new MemoryStream();
 
         // Flatten drives folders and files so that folder/file indices are contiguous per-drive
         List<DriveTest> driveList = new List<DriveTest>();
@@ -281,6 +281,8 @@ internal class SgaV2Parser : ISgaParser
         // write TOC
         nameBuffer.Seek(0, SeekOrigin.Begin);
         nameBuffer.CopyTo(toc);
+        toc.Seek(0, SeekOrigin.Begin);
+        byte[]? tocHash = ParserUtils.HashMD5(toc, toc.Length, "DFC9AF62-FC1B-4180-BC27-11CCE87D3EFF");
 
         ParserUtils.WriteStaticString(tempStream, "_ARCHIVE", 8);
         ParserUtils.WriteUInt32(tempStream, (uint)archive.Version);
@@ -290,36 +292,32 @@ internal class SgaV2Parser : ISgaParser
         
         ParserUtils.WriteWideStaticString(tempStream, archive.ArchiveName, 128);
         
-        tempStream.Write(emptyHash);
+        tempStream.Write(tocHash);
         
-        ParserUtils.WriteUInt32(tempStream, (uint)toc.Position);
-        ParserUtils.WriteUInt32(tempStream, (uint)(toc.Position + 180 ));
+        ParserUtils.WriteUInt32(tempStream, (uint)toc.Length);
+        ParserUtils.WriteUInt32(tempStream, (uint)(toc.Length + 180 ));
         
-        toc.Seek(0, SeekOrigin.Begin);
         toc.CopyTo(tempStream);
 
         byte[] emptyMetaData = new byte[264];
 
         foreach(var file in fileList)
         {
-            using var contents = file.Open();
-
             tempStream.Write(emptyMetaData);
-
-            if(file.StorageType == StorageType.Uncompress)
-            {
-                contents.CopyTo(tempStream);
-            }
-            else
-            {
-                using var compressed = new ZLibStream(tempStream, CompressionMode.Compress, true);
-                contents.CopyTo(compressed);
-            }
+            using var contents = file.GetExactStream();
+            contents.CopyTo(tempStream);
         }
 
-        // write data block
-        //dataBlock.Seek(0, SeekOrigin.Begin);
-        //dataBlock.CopyTo(sgaStream);
+        tempStream.Position = 180;
+        byte[]? fileHash = ParserUtils.HashMD5(tempStream, tempStream.Length-tempStream.Position, "E01519D6-2DB7-4640-AF54-0A23319C56C3");
+        
+        tempStream.Position = 12;
+        tempStream.Write(fileHash);
+
+        sgaStream.Position = 0;
+        tempStream.Position = 0;
+        tempStream.CopyTo(sgaStream);
+        sgaStream.SetLength(sgaStream.Position);
     }
 
     // Mock implementation. For testing only. Will be replaces by actual implementation when i will be satisfied by the public interface.

--- a/OpenCompote/Parsers/SgaV2Parser.cs
+++ b/OpenCompote/Parsers/SgaV2Parser.cs
@@ -33,7 +33,7 @@ internal class SgaV2Parser : ISgaParser
     {
         List<DriveRecord> driveList = new List<DriveRecord>();
         List<FolderRecord> folderList = new List<FolderRecord>();
-        List<SgaFile> fileList = new List<SgaFile>();
+        List<FileRecord> fileList = new List<FileRecord>();
 
         byte[] fileHash = ParserUtils.ReadHash(sgaStream);
 
@@ -110,10 +110,7 @@ internal class SgaV2Parser : ISgaParser
             uint compressSize = ParserUtils.ReadUInt32(sgaStream);
             uint decompressSize = ParserUtils.ReadUInt32(sgaStream);
 
-            uint nameStart = nameOffset + 180 + nameListOffset;
-            string fileName = ParserUtils.ReadDynamicString(sgaStream, nameStart);
-
-            var file = new SgaFile(fileName, storageFlag, rawDataOffset + dataOffset, compressSize, decompressSize);
+            var file = new FileRecord(nameOffset, storageFlag, rawDataOffset + dataOffset, compressSize, decompressSize);
             fileList.Add(file);
         }
 
@@ -149,9 +146,18 @@ internal class SgaV2Parser : ISgaParser
 
                 for (ushort i = currentRecord.FirstFile; i < currentRecord.LastFile; i++)
                 {
-                    SgaFile currentFile = fileList[i];
-                    currentFile.Drive = newDrive;
-                    currentFile.Parent = currentFolder;
+                    FileRecord fileRecord = fileList[i];
+
+                    uint fileNameOffset = fileRecord.NameOffset + 180 + nameListOffset;
+                    string fileName = ParserUtils.ReadDynamicString(sgaStream, fileNameOffset);
+
+                    SgaFile currentFile = new SgaFile(fileName,
+                                                      fileRecord.StorageType,
+                                                      fileRecord.RawDataOffset,
+                                                      fileRecord.CompressedSize,
+                                                      fileRecord.Size,
+                                                      newDrive,
+                                                      currentFolder);
                     currentFolder._contents.Add(currentFile);
                 }
             }
@@ -253,7 +259,7 @@ internal class SgaV2Parser : ISgaParser
         foreach (var f in folderList)
         {
             uint folderNameOffset = (uint)nameBuffer.Position;
-            ParserUtils.WriteDynamicString(nameBuffer, f.Folder.Name);
+            ParserUtils.WriteDynamicString(nameBuffer, f.Folder.Path);
 
             ParserUtils.WriteUInt32(toc, folderNameOffset);
             ParserUtils.WriteUInt16(toc, f.FirstFolder);

--- a/OpenCompote/Parsers/Structs/FileRecord.cs
+++ b/OpenCompote/Parsers/Structs/FileRecord.cs
@@ -1,0 +1,20 @@
+using System;
+using OpenCompote.SGA;
+
+namespace OpenCompote;
+
+internal readonly struct FileRecord(
+    uint nameOffset,
+    StorageType storageType,
+    uint rawDataOffset,
+    uint compressSize,
+    uint decompressSize
+
+)
+{
+    public uint NameOffset { get; } = nameOffset;
+    public StorageType StorageType { get; } = storageType;
+    public uint RawDataOffset { get; } = rawDataOffset;
+    public uint CompressedSize { get; } = compressSize;
+    public uint Size { get; } = decompressSize;
+}

--- a/OpenCompote/Parsers/Structs/FolderRecord.cs
+++ b/OpenCompote/Parsers/Structs/FolderRecord.cs
@@ -13,3 +13,12 @@ internal readonly struct FolderRecord(
     public ushort FirstFile { get; } = firstFile;
     public ushort LastFile { get; } = lastFile;
 }
+
+internal class FolderWriterRecord(SgaFolder folder)
+{
+    public SgaFolder Folder { get; set; } = folder;
+    public ushort FirstFolder {get; set;}
+    public ushort LastFolder {get; set;}
+    public ushort FirstFile {get; set;}
+    public ushort LastFile {get; set;}
+}

--- a/OpenCompote/SgaArchive.cs
+++ b/OpenCompote/SgaArchive.cs
@@ -4,6 +4,9 @@ using OpenCompote.SGA.Parsers;
 
 namespace OpenCompote.SGA;
 
+/// <summary>
+/// Represents the open archive file itself.
+/// </summary>
 public class SgaArchive: IDisposable
 {
     private readonly ReadOnlyCollection<SgaDrive> _driveCollection;
@@ -57,8 +60,9 @@ public class SgaArchive: IDisposable
     public int BlockSize {get; set;}
 
     /// <summary>
-    /// Create constructor. - Initializes new instance of SgaArchive on the given stream in the specific mode, using specific Sga version, specifying whether to leave the stream open.
+    /// Create constructor. - Initializes new instance of SgaArchive on the given empty stream in the specific mode, using specific SGA version, specifying whether to leave the stream open. 
     /// </summary>
+    /// <remarks>This constructor should be used only for creating a new SGA archive. If you want to just open already existing fle, please use the Open constructor</remarks>
     /// <param name="stream">The stream where the SGA archive is to be stored.</param>
     /// <param name="mode">Mode in which the archive should operate with.</param>
     /// <param name="version">Expected SGA version of the archive.</param>
@@ -119,7 +123,7 @@ public class SgaArchive: IDisposable
     /// <param name="stream">The stream containing the SGA archive.</param>
     /// <param name="mode">Mode in which the archive should operate with.</param>
     /// <param name="leaveOpen">true to leave the stream open upon disposing the SgaArchive, otherwise false.</param>
-    /// <remarks>This constructor cannot be used with SgaMode.Create. For creating new empty archives please use the open constructor.</remarks>
+    /// <remarks>This constructor cannot be used with SgaMode.Create. For creating new empty archives please use the Create constructor.</remarks>
     public SgaArchive(Stream stream, SgaMode mode, bool leaveOpen = false): this(stream, mode, null, leaveOpen) {}
 
     #if DEBUG // For unit testing of the public API only, Do not include to release builds (Not very nice, but works.) 
@@ -178,6 +182,9 @@ public class SgaArchive: IDisposable
         return _drives.FirstOrDefault((drive)=>{return drive.Name == driveName || drive.Alias == driveName;});
     }
 
+    /// <summary>
+    /// NOT IMPLEMENTED! DO NOT USE
+    /// </summary>
     public SgaEntry GetEntry(string entryName)
     {
         throw new NotImplementedException();

--- a/OpenCompote/SgaDrive.cs
+++ b/OpenCompote/SgaDrive.cs
@@ -7,8 +7,8 @@ namespace OpenCompote.SGA;
 /// </summary>
 public class SgaDrive
 {
-    private string _Alias;
-    private string _Name;
+    private string _alias;
+    private string _name;
     
     /// <summary>
     /// Gets the alias of the drive.
@@ -18,14 +18,14 @@ public class SgaDrive
         get
         {
             ThrowIfDeleted();
-            return _Alias;
+            return _alias;
         }
         set
         {
             ThrowIfDeleted();
             if(Archive!.Mode == SgaMode.Read)
                 throw new NotSupportedException("Writing is not supported.");
-            _Alias = value;
+            _alias = value;
         }
     }
 
@@ -37,14 +37,14 @@ public class SgaDrive
         get
         {
             ThrowIfDeleted();
-            return _Name;
+            return _name;
         }
         set
         {
             ThrowIfDeleted();
             if(Archive!.Mode == SgaMode.Read)
                 throw new NotSupportedException("Writing is not supported.");
-            _Name = value;
+            _name = value;
         }
     }
 
@@ -60,8 +60,8 @@ public class SgaDrive
 
     internal SgaDrive(string alias, string name, SgaArchive archive)
     {
-        _Alias = alias;
-        _Name = name;
+        _alias = alias;
+        _name = name;
         Archive = archive;
         RootFolder = new SgaFolder(name, this, null);
     }

--- a/OpenCompote/SgaDrive.cs
+++ b/OpenCompote/SgaDrive.cs
@@ -2,11 +2,17 @@ using System.Runtime.InteropServices;
 
 namespace OpenCompote.SGA;
 
+/// <summary>
+/// Represents a SGA archive drive.
+/// </summary>
 public class SgaDrive
 {
     private string _Alias;
     private string _Name;
     
+    /// <summary>
+    /// Gets the alias of the drive.
+    /// </summary>
     public string Alias
     {
         get
@@ -22,6 +28,10 @@ public class SgaDrive
             _Alias = value;
         }
     }
+
+    /// <summary>
+    /// Gets the name of the drive.
+    /// </summary>
     public string Name
     {
         get
@@ -37,7 +47,15 @@ public class SgaDrive
             _Name = value;
         }
     }
+
+    /// <summary>
+    /// Gets the SGA archive that the drive belongs to.
+    /// </summary>
     public SgaArchive? Archive {get; private set;}
+
+    /// <summary>
+    /// Gets the RootFolder of this drive.
+    /// </summary>
     public SgaFolder RootFolder {get; internal set;}
 
     internal SgaDrive(string alias, string name, SgaArchive archive)
@@ -48,6 +66,11 @@ public class SgaDrive
         RootFolder = new SgaFolder(name, this, null);
     }
 
+    /// <summary>
+    /// Deletes the drive from the archive.
+    /// </summary>
+    /// <exception cref="NotSupportedException">The SGA archive for this drive was open in readonly mode.</exception>
+    /// <exception cref="ObjectDisposedException">The SGA archive for this entry has been disposed.</exception>
     public void Delete()
     {
         if(Archive == null)
@@ -70,7 +93,10 @@ public class SgaDrive
     }
 
     // ------------------------ Extending functions ------------------------
-    // List of future ideas.  
+    // List of future ideas.
+    /// <summary>
+    /// NOT IMPLEMENTED! DO NOT USE
+    /// </summary>  
     public SgaEntry GetEntry(string entryName)
     {
         throw new NotImplementedException();

--- a/OpenCompote/SgaEntry.cs
+++ b/OpenCompote/SgaEntry.cs
@@ -7,6 +7,9 @@ public abstract class SgaEntry
 {
     protected string _Name = "";
 
+    /// <summary>
+    /// Gets the name of the entry in the zip archive.
+    /// </summary>
     public string Name
     {
         get
@@ -23,6 +26,9 @@ public abstract class SgaEntry
         }
     }
 
+    /// <summary>
+    /// Gets the relative path of the entry in the zip archive.
+    /// </summary>
     public string Path
     {
         get
@@ -44,15 +50,29 @@ public abstract class SgaEntry
         }
     }
 
+    /// <summary>
+    /// Gets the parent drive of this entry.
+    /// </summary>
     public SgaFolder? Parent {get; internal set;}
+
+    /// <summary>
+    /// Gets the SGA drive that the entry belongs to.
+    /// </summary>
     public SgaDrive? Drive {get; internal set;}
+    
     internal abstract void Delete(bool subDelete);
 
+    /// <summary>
+    /// Deletes the entry from the archive.
+    /// </summary>
+    /// <exception cref="NotSupportedException">The SGA archive for this drive was open in readonly mode.</exception>
+    /// <exception cref="ObjectDisposedException">The SGA archive for this entry has been disposed.</exception>
     public void Delete()
     {
         Delete(false);
     }
-    protected void ThrowIfDeleted()
+
+    protected internal void ThrowIfDeleted()
     {
         ObjectDisposedException.ThrowIf(Drive == null || Drive.Archive == null,this);
         Drive.Archive.ThrowIfDisposed();

--- a/OpenCompote/SgaEntry.cs
+++ b/OpenCompote/SgaEntry.cs
@@ -6,6 +6,7 @@ namespace OpenCompote.SGA;
 public abstract class SgaEntry
 {
     protected string _Name = "";
+    protected string _Path = "";
 
     public string Name
     {
@@ -20,6 +21,15 @@ public abstract class SgaEntry
             if(Drive!.Archive!.Mode == SgaMode.Read)
                 throw new NotSupportedException("Writing is not supported.");
             _Name = value;
+        }
+    }
+
+    public string Path
+    {
+        get
+        {
+            ThrowIfDeleted();
+            return _Path;
         }
     }
 

--- a/OpenCompote/SgaEntry.cs
+++ b/OpenCompote/SgaEntry.cs
@@ -5,7 +5,7 @@ namespace OpenCompote.SGA;
 
 public abstract class SgaEntry
 {
-    protected string _Name = "";
+    protected string _name = "";
 
     /// <summary>
     /// Gets the name of the entry in the zip archive.
@@ -15,14 +15,14 @@ public abstract class SgaEntry
         get
         {
             ThrowIfDeleted();
-            return _Name;
+            return _name;
         }
         set
         {
             ThrowIfDeleted();
             if(Drive!.Archive!.Mode == SgaMode.Read)
                 throw new NotSupportedException("Writing is not supported.");
-            _Name = value;
+            _name = value;
         }
     }
 
@@ -39,8 +39,8 @@ public abstract class SgaEntry
             SgaEntry? current = this;
             while (current != null)
             {
-                if(current._Name != "")
-                    pathParts.Add(current._Name);
+                if(current._name != "")
+                    pathParts.Add(current._name);
 
                 current = current.Parent;
             }

--- a/OpenCompote/SgaEntry.cs
+++ b/OpenCompote/SgaEntry.cs
@@ -6,7 +6,6 @@ namespace OpenCompote.SGA;
 public abstract class SgaEntry
 {
     protected string _Name = "";
-    protected string _Path = "";
 
     public string Name
     {
@@ -29,7 +28,19 @@ public abstract class SgaEntry
         get
         {
             ThrowIfDeleted();
-            return _Path;
+            var pathParts = new List<string>();
+            
+            SgaEntry? current = this;
+            while (current != null)
+            {
+                if(current._Name != "")
+                    pathParts.Add(current._Name);
+
+                current = current.Parent;
+            }
+            
+            pathParts.Reverse();
+            return string.Join("\\", pathParts);
         }
     }
 

--- a/OpenCompote/SgaFile.cs
+++ b/OpenCompote/SgaFile.cs
@@ -19,7 +19,6 @@ public class SgaFile: SgaEntry
         _Name = name;
         StorageType = type;
         Parent = parent;
-        _Path = Parent.Path + '\\' + name;
     }
 
     internal SgaFile(string name, StorageType type, uint dataOffset, uint compressedSize, uint size, SgaDrive drive, SgaFolder parent)
@@ -31,7 +30,6 @@ public class SgaFile: SgaEntry
         Size = size;
         Drive = drive;
         Parent = parent;
-        _Path = Parent.Path + '\\' + name;
         _isInStream = true;
     }
 
@@ -51,9 +49,12 @@ public class SgaFile: SgaEntry
         }
     }
 
-    internal Stream GetExactStream()
+    internal Stream GetResultStream()
     {
-        return new ReadSubStream(Drive!.Archive!._archiveStream, _DataOffset, CompressedSize);
+        if(_isInStream && _fileContents == null)
+            return new ReadSubStream(Drive!.Archive!._archiveStream, _DataOffset, CompressedSize);
+            
+        return _fileContents!;    
     }
 
     internal override void Delete(bool subDelete)

--- a/OpenCompote/SgaFile.cs
+++ b/OpenCompote/SgaFile.cs
@@ -127,7 +127,10 @@ public class SgaFile: SgaEntry
 
     // ------------------------ Extending functions ------------------------
     // List of future ideas.  
-        public void ExtractToFile(string destination, bool overwrite = false)
+    /// <summary>
+    /// NOT IMPLEMENTED! DO NOT USE
+    /// </summary>
+    public void ExtractToFile(string destination, bool overwrite = false)
     {
         throw new NotImplementedException();
     }

--- a/OpenCompote/SgaFile.cs
+++ b/OpenCompote/SgaFile.cs
@@ -1,4 +1,6 @@
 using System.IO.Compression;
+using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
 using OpenCompote.SGA.CustomStreams;
 
 namespace OpenCompote.SGA;
@@ -12,8 +14,10 @@ public class SgaFile: SgaEntry
     private StorageType _storageType;
 
     /// <summary>
-    /// Gets value that indicates whether then file is stored compressed or not.
+    /// Gets value that indicates whether the file is compressed or not.
     /// </summary>
+    /// <exception cref="ObjectDisposedException">The SGA archive for this file has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">The archive is opened in read-only mode or file is currently open."</exception>
     public StorageType StorageType
     {
         get
@@ -25,8 +29,24 @@ public class SgaFile: SgaEntry
         {
             ThrowIfDeleted();
             if(Drive!.Archive!.Mode == SgaMode.Read)
-                throw new NotSupportedException("Writing is not supported.");
+                throw new InvalidOperationException("Writing is not supported.");
+            if(_isOpen)
+                throw new InvalidOperationException("Cannot change Storage type when file is open.");
+            if(_storageType == value)
+                return;
 
+            SetupFileContents();
+
+            if(value == StorageType.Uncompress)
+            {
+                _fileContents = DecompressFileContents();
+            }
+            else if(_storageType == StorageType.Uncompress)
+            {
+                _fileContents = CompressFileContents();
+            }
+
+            CompressedSize = (uint)_fileContents!.Length;
             _storageType = value;
         }
     }
@@ -100,6 +120,51 @@ public class SgaFile: SgaEntry
         _fileContents?.Dispose();
     }
 
+    private void SetupFileContents()
+    {
+        if(_fileContents == null)
+        {
+            _fileContents = new MemoryStream();
+
+            if (_isInStream)
+            {
+                var tempStream = new ReadSubStream(Drive!.Archive!._archiveStream, _dataOffset, CompressedSize);;
+                tempStream.CopyTo(_fileContents);
+                _fileContents.Position = 0;
+            }
+
+        }
+    }
+
+    private MemoryStream CompressFileContents()
+    {
+        if(_fileContents == null)
+            ArgumentNullException.ThrowIfNull(_fileContents);
+        
+        _fileContents.Position = 0;
+        var compressedStream = new MemoryStream();
+        var zLibStream = new ZLibStream(compressedStream, CompressionMode.Compress, true);
+        _fileContents.CopyTo(zLibStream);
+        
+        // Force ZLIB stream to write contents to the compressedStream. 
+        // If the zlibStream wouldn`t be closed, bytes would be missing from the end of the compressed stream.
+        zLibStream.Dispose();
+        compressedStream.Position = 0; // Reset position because CopyTo moves it.
+        return compressedStream;
+    }
+
+    private MemoryStream DecompressFileContents()
+    {
+        if(_fileContents == null)
+            ArgumentNullException.ThrowIfNull(_fileContents);
+
+        var zLibStream = new ZLibStream(_fileContents, CompressionMode.Decompress, true);
+        var decompressedStream = new MemoryStream();
+        zLibStream.CopyTo(decompressedStream);
+        decompressedStream.Position = 0; // Reset position because CopyTo moves it.
+        return decompressedStream;
+    }
+
     private Stream OpenReadOnly()
     {
         ReadSubStream compressed = new ReadSubStream(Drive!.Archive!._archiveStream, _dataOffset, CompressedSize);
@@ -115,21 +180,12 @@ public class SgaFile: SgaEntry
         if (_isOpen)
             throw new IOException("Files cannot be opened multiple times in Update/Create mode.");
 
-        if (_isInStream && _fileContents == null)
-        {
-            _fileContents = new MemoryStream();
-            var tempStream = OpenReadOnly();
-            tempStream.CopyTo(_fileContents);
-        }
-        else if(StorageType != StorageType.Uncompress && _fileContents != null)
-        {
-            var zLibStream = new ZLibStream(_fileContents, CompressionMode.Decompress, true);
-            _fileContents = new MemoryStream();
-            zLibStream.CopyTo(_fileContents); 
-        }
+        SetupFileContents();
+        
+        if(StorageType != StorageType.Uncompress)
+            _fileContents = DecompressFileContents();
 
         _fileContents ??= new MemoryStream();
-        _fileContents.Position = 0;
         _isOpen = true;
 
         return new WrapperStream(_fileContents, () =>
@@ -137,17 +193,9 @@ public class SgaFile: SgaEntry
             Size = (uint)_fileContents.Length;
 
             if(StorageType != StorageType.Uncompress)
-            {   
-                _fileContents.Position = 0;
-                var compressedStream = new MemoryStream();
-                var zLibStream = new ZLibStream(compressedStream, CompressionMode.Compress, true);
-                _fileContents.CopyTo(zLibStream);
-                _fileContents = compressedStream;
-                zLibStream.Dispose();
-            }
+                _fileContents = CompressFileContents();
 
             CompressedSize = (uint)_fileContents.Length;
-            _fileContents.Position = 0;
             _isOpen = false;
         });
     }

--- a/OpenCompote/SgaFile.cs
+++ b/OpenCompote/SgaFile.cs
@@ -47,6 +47,11 @@ public class SgaFile: SgaEntry
         }
     }
 
+    internal Stream GetExactStream()
+    {
+        return new ReadSubStream(Drive!.Archive!._archiveStream, _DataOffset, CompressedSize);
+    }
+
     internal override void Delete(bool subDelete)
     {
         ThrowIfDeleted();

--- a/OpenCompote/SgaFile.cs
+++ b/OpenCompote/SgaFile.cs
@@ -19,15 +19,19 @@ public class SgaFile: SgaEntry
         _Name = name;
         StorageType = type;
         Parent = parent;
+        _Path = Parent.Path + '\\' + name;
     }
 
-    internal SgaFile(string name, StorageType type, uint dataOffset, uint compressedSize, uint size)
+    internal SgaFile(string name, StorageType type, uint dataOffset, uint compressedSize, uint size, SgaDrive drive, SgaFolder parent)
     {
         _DataOffset = dataOffset;
         _Name = name;
         StorageType = type;
         CompressedSize = compressedSize;
         Size = size;
+        Drive = drive;
+        Parent = parent;
+        _Path = Parent.Path + '\\' + name;
         _isInStream = true;
     }
 

--- a/OpenCompote/SgaFile.cs
+++ b/OpenCompote/SgaFile.cs
@@ -37,7 +37,7 @@ public class SgaFile: SgaEntry
     {   
         Drive = drive;
         _name = name;
-        StorageType = type;
+        _storageType = type;
         Parent = parent;
     }
 
@@ -45,7 +45,7 @@ public class SgaFile: SgaEntry
     {
         _dataOffset = dataOffset;
         _name = name;
-        StorageType = type;
+        _storageType = type;
         CompressedSize = compressedSize;
         Size = size;
         Drive = drive;

--- a/OpenCompote/SgaFile.cs
+++ b/OpenCompote/SgaFile.cs
@@ -101,6 +101,8 @@ public class SgaFile: SgaEntry
         return new WrapperStream(_fileContents, () =>
         {
             _isOpen = false;
+            Size = (uint)_fileContents.Length;
+            CompressedSize = (uint)_fileContents.Length;
         });
     }
 

--- a/OpenCompote/SgaFile.cs
+++ b/OpenCompote/SgaFile.cs
@@ -6,25 +6,45 @@ namespace OpenCompote.SGA;
 public class SgaFile: SgaEntry
 {
     private readonly bool _isInStream = false;
-    private readonly uint _DataOffset;
+    private readonly uint _dataOffset;
     private Stream? _fileContents;
     private bool _isOpen;
-    public StorageType StorageType {get; set;}
+    private StorageType _storageType;
+
+    /// <summary>
+    /// Gets value that indicates whether then file is stored compressed or not.
+    /// </summary>
+    public StorageType StorageType
+    {
+        get
+        {
+            ThrowIfDeleted();
+            return _storageType;
+        }
+        set
+        {
+            ThrowIfDeleted();
+            if(Drive!.Archive!.Mode == SgaMode.Read)
+                throw new NotSupportedException("Writing is not supported.");
+
+            _storageType = value;
+        }
+    }
     public uint CompressedSize {get; private set;}
     public uint Size {get; private set;}
 
     internal SgaFile(string name, StorageType type, SgaDrive drive, SgaFolder parent)
     {   
         Drive = drive;
-        _Name = name;
+        _name = name;
         StorageType = type;
         Parent = parent;
     }
 
     internal SgaFile(string name, StorageType type, uint dataOffset, uint compressedSize, uint size, SgaDrive drive, SgaFolder parent)
     {
-        _DataOffset = dataOffset;
-        _Name = name;
+        _dataOffset = dataOffset;
+        _name = name;
         StorageType = type;
         CompressedSize = compressedSize;
         Size = size;
@@ -33,6 +53,13 @@ public class SgaFile: SgaEntry
         _isInStream = true;
     }
 
+    /// <summary>
+    /// Opens the file from the SGA archive.
+    /// </summary>
+    /// <returns>The stream that represents the contents of the file.</returns>
+    /// <exception cref="ObjectDisposedException">The SGA archive for this folder has been disposed.</exception>
+    /// <exception cref="IOException">The entry is already currently open for writing.</exception>
+    /// <exception cref="InvalidOperationException">The archive was opened in invalid mode.</exception>
     public Stream Open()
     {   
         ThrowIfDeleted();
@@ -52,7 +79,7 @@ public class SgaFile: SgaEntry
     internal Stream GetResultStream()
     {
         if(_isInStream && _fileContents == null)
-            return new ReadSubStream(Drive!.Archive!._archiveStream, _DataOffset, CompressedSize);
+            return new ReadSubStream(Drive!.Archive!._archiveStream, _dataOffset, CompressedSize);
             
         return _fileContents!;    
     }
@@ -75,7 +102,7 @@ public class SgaFile: SgaEntry
 
     private Stream OpenReadOnly()
     {
-        ReadSubStream compressed = new ReadSubStream(Drive!.Archive!._archiveStream, _DataOffset, CompressedSize);
+        ReadSubStream compressed = new ReadSubStream(Drive!.Archive!._archiveStream, _dataOffset, CompressedSize);
 
         if(StorageType == StorageType.Uncompress)
             return compressed;

--- a/OpenCompote/SgaFile.cs
+++ b/OpenCompote/SgaFile.cs
@@ -94,15 +94,34 @@ public class SgaFile: SgaEntry
             var tempStream = OpenReadOnly();
             tempStream.CopyTo(_fileContents);
         }
+        else if(StorageType != StorageType.Uncompress && _fileContents != null)
+        {
+            var zLibStream = new ZLibStream(_fileContents, CompressionMode.Decompress, true);
+            _fileContents = new MemoryStream();
+            zLibStream.CopyTo(_fileContents); 
+        }
 
         _fileContents ??= new MemoryStream();
         _fileContents.Position = 0;
         _isOpen = true;
+
         return new WrapperStream(_fileContents, () =>
         {
-            _isOpen = false;
             Size = (uint)_fileContents.Length;
+
+            if(StorageType != StorageType.Uncompress)
+            {   
+                _fileContents.Position = 0;
+                var compressedStream = new MemoryStream();
+                var zLibStream = new ZLibStream(compressedStream, CompressionMode.Compress, true);
+                _fileContents.CopyTo(zLibStream);
+                _fileContents = compressedStream;
+                zLibStream.Dispose();
+            }
+
             CompressedSize = (uint)_fileContents.Length;
+            _fileContents.Position = 0;
+            _isOpen = false;
         });
     }
 

--- a/OpenCompote/SgaFolder.cs
+++ b/OpenCompote/SgaFolder.cs
@@ -7,6 +7,9 @@ public class SgaFolder: SgaEntry
     internal readonly List<SgaEntry> _contents;
     private readonly ReadOnlyCollection<SgaEntry> _contentCollection;
 
+    /// <summary>
+    /// Gets the collection of entries that are currently in the current folder.
+    /// </summary>
     public ReadOnlyCollection<SgaEntry> Contents
     {
         get {
@@ -25,6 +28,13 @@ public class SgaFolder: SgaEntry
         _Name = path.Split('\\').Last();
     }
 
+    /// <summary>
+    /// Creates an empty subfolder in the current folder.
+    /// </summary>
+    /// <param name="name">The name of the folder to be created</param>
+    /// <returns>New empty subfolder.</returns>
+    /// <exception cref="NotSupportedException">The SGA archive for this drive was open in readonly mode.</exception>
+    /// <exception cref="ObjectDisposedException">The SGA archive for this entry has been disposed.</exception>
     public SgaFolder AddFolder(string name)
     {
         ThrowIfDeleted(); // Test if this folder was deleted.
@@ -37,6 +47,13 @@ public class SgaFolder: SgaEntry
         return newFolder;
     }
 
+    /// <summary>
+    /// Created an empty file in the current folder.
+    /// </summary>
+    /// <param name="name">The name of the new file.</param>
+    /// <param name="type">The storage type of the new file.</param>
+    /// <returns>New empty file.</returns>
+    /// <exception cref="NotSupportedException"></exception>
     public SgaFile AddFile(string name, StorageType type)
     {
         ThrowIfDeleted(); // Test if this folder was deleted.
@@ -70,7 +87,10 @@ public class SgaFolder: SgaEntry
     }
 
     // ------------------------ Extending functions ------------------------
-    // List of future ideas. 
+    // List of future ideas.
+    /// <summary>
+    /// NOT IMPLEMENTED! DO NOT USE
+    /// </summary> 
     public void ExtractToDirectory(string destination, bool overwrite = false)
     {
         throw new NotImplementedException();

--- a/OpenCompote/SgaFolder.cs
+++ b/OpenCompote/SgaFolder.cs
@@ -33,7 +33,7 @@ public class SgaFolder: SgaEntry
         if(Drive!.Archive!.Mode == SgaMode.Read)
             throw new NotSupportedException("Writing is not supported in this mode.");
 
-        SgaFolder newFolder = new SgaFolder(name, Drive!, this);
+        SgaFolder newFolder = new SgaFolder(Path + '\\' + name, Drive!, this);
         _contents.Add(newFolder);
         return newFolder;
     }

--- a/OpenCompote/SgaFolder.cs
+++ b/OpenCompote/SgaFolder.cs
@@ -23,7 +23,6 @@ public class SgaFolder: SgaEntry
         Parent = parent;
 
         _Name = path.Split('\\').Last();
-        _Path = path;
     }
 
     public SgaFolder AddFolder(string name)

--- a/OpenCompote/SgaFolder.cs
+++ b/OpenCompote/SgaFolder.cs
@@ -15,13 +15,15 @@ public class SgaFolder: SgaEntry
         }
     }
 
-    internal SgaFolder(string name, SgaDrive drive, SgaFolder? parent)
+    internal SgaFolder(string path, SgaDrive drive, SgaFolder? parent)
     {   
         _contents = new List<SgaEntry>();
         _contentCollection = new ReadOnlyCollection<SgaEntry>(_contents);
         Drive = drive;
         Parent = parent;
-        _Name = name;
+
+        _Name = path.Split('\\').Last();
+        _Path = path;
     }
 
     public SgaFolder AddFolder(string name)

--- a/OpenCompote/SgaFolder.cs
+++ b/OpenCompote/SgaFolder.cs
@@ -25,7 +25,7 @@ public class SgaFolder: SgaEntry
         Drive = drive;
         Parent = parent;
 
-        _Name = path.Split('\\').Last();
+        _name = path.Split('\\').Last();
     }
 
     /// <summary>
@@ -53,7 +53,8 @@ public class SgaFolder: SgaEntry
     /// <param name="name">The name of the new file.</param>
     /// <param name="type">The storage type of the new file.</param>
     /// <returns>New empty file.</returns>
-    /// <exception cref="NotSupportedException"></exception>
+    /// <exception cref="NotSupportedException">The SGA archive for this drive was open in readonly mode.</exception>
+    /// <exception cref="ObjectDisposedException">The SGA archive for this folder has been disposed.</exception>
     public SgaFile AddFile(string name, StorageType type)
     {
         ThrowIfDeleted(); // Test if this folder was deleted.

--- a/tests/SgaArchiveTest.cs
+++ b/tests/SgaArchiveTest.cs
@@ -220,6 +220,7 @@ public class SgaArchiveTest
             Assert.Single(drive.RootFolder.Contents);
             Assert.Same(newFolder, drive.RootFolder.Contents[0]);
             Assert.Equal("SubFolder", newFolder.Name);
+            Assert.Equal("Name\\SubFolder", newFolder.Path);
             Assert.Same(drive.RootFolder, newFolder.Parent);
             Assert.Same(drive, newFolder.Drive);
         }
@@ -276,6 +277,7 @@ public class SgaArchiveTest
             Assert.Single(drive.RootFolder.Contents);
             Assert.Same(newFile, drive.RootFolder.Contents[0]);
             Assert.Equal("TestFile.txt", newFile.Name);
+            Assert.Equal("Name\\TestFile.txt", newFile.Path);
             Assert.Equal(StorageType.Uncompress, newFile.StorageType);
             Assert.Same(drive.RootFolder, newFile.Parent);
             Assert.Same(drive, newFile.Drive);

--- a/tests/SgaArchiveTest.cs
+++ b/tests/SgaArchiveTest.cs
@@ -465,6 +465,64 @@ public class SgaArchiveTest
         }
     }
 
+    [Fact]
+    public void ChangeFileContents_AndReopenTheFile()
+    {
+        var stream = new MemoryStream();
+        var parser = new MockParser([
+            new TestDrive{
+                Name = "DriveName",
+                Alias = "DriveAlias",
+                RootFolder = new TestFolder{
+                    Name = "",
+                    Folders = [new TestFolder{
+                        Name= "Data",
+                        Folders = [],
+                        Files = []
+                    }],
+                    Files = []
+                }
+            }
+        ],[
+            new TestDrive{
+                Name = "DriveName",
+                Alias = "DriveAlias",
+                RootFolder = new TestFolder{
+                    Name = "",
+                    Folders = [new TestFolder{
+                        Name= "Data",
+                        Folders = [],
+                        Files = [new TestFile{
+                            Name= "File1",
+                            StorageType = StorageType.StreamCompress,
+                            FileContent = "File Contents"
+                        }]
+                    }],
+                    Files = []
+                }
+            }
+        ]);
+
+        using (var archive = new SgaArchive(stream, SgaMode.Write, SgaVersion.V2, parser))
+        {
+            SgaFolder dataDrive = (SgaFolder)archive.GetDrive("DriveName")!.RootFolder!.Contents[0];
+
+            SgaFile file = dataDrive.AddFile("File1", StorageType.StreamCompress);
+
+            using(var contents = file.Open()){
+                byte[] inputBytes = Encoding.UTF8.GetBytes("File Contents");
+                contents.Write(inputBytes);
+            }
+
+            using(var contents = file.Open())
+            {
+                byte[] outputBytes = new byte[file.Size];
+                contents.ReadExactly(outputBytes);
+                Assert.Equal("File Contents", Encoding.Default.GetString(outputBytes));
+            }
+        }
+    }
+
     #endregion
 
     #region Delete Tests

--- a/tests/SgaArchiveTest.cs
+++ b/tests/SgaArchiveTest.cs
@@ -399,6 +399,11 @@ public class SgaArchiveTest
         }
     }
 
+
+    #endregion
+
+    #region Edit Tests
+
     [Fact]
     public void ChangeName_InEditMode_ChangesPathAsWell()
     {
@@ -520,6 +525,191 @@ public class SgaArchiveTest
                 contents.ReadExactly(outputBytes);
                 Assert.Equal("File Contents", Encoding.Default.GetString(outputBytes));
             }
+        }
+    }
+
+    [Fact]
+    public void ChangeFileStorageType_ToCompressed_CompressesContents()
+    {
+        var stream = new MemoryStream();
+        var parser = new MockParser([],[
+            new TestDrive{
+                Name = "DriveName",
+                Alias = "DriveAlias",
+                RootFolder = new TestFolder{
+                    Name = "",
+                    Folders = [new TestFolder{
+                        Name= "Data",
+                        Folders = [],
+                        Files = [new TestFile{
+                            Name= "File1",
+                            StorageType = StorageType.StreamCompress,
+                            FileContent = "File Contents"
+                        }]
+                    }],
+                    Files = []
+                }
+            }
+        ]);
+
+        using (var archive = new SgaArchive(stream, SgaMode.Write, SgaVersion.V2, parser))
+        {
+            SgaDrive drive = archive.AddDrive("DriveAlias", "DriveName");
+            drive.RootFolder.Name = "";
+            SgaFolder data = drive.RootFolder.AddFolder("Data");
+            SgaFile file1 = data.AddFile("File1", StorageType.Uncompress);
+            
+            using(var contents = file1.Open()){
+                byte[] inputBytes = Encoding.UTF8.GetBytes("File Contents");
+                contents.Write(inputBytes);
+            }
+
+            file1.StorageType = StorageType.StreamCompress;
+            
+        }
+    }
+
+    [Fact]
+    public void ChangeFileStorageType_ToUncompressed_DecompressesContents()
+    {
+        var stream = new MemoryStream();
+        var parser = new MockParser([],[
+            new TestDrive{
+                Name = "DriveName",
+                Alias = "DriveAlias",
+                RootFolder = new TestFolder{
+                    Name = "",
+                    Folders = [new TestFolder{
+                        Name= "Data",
+                        Folders = [],
+                        Files = [new TestFile{
+                            Name= "File1",
+                            StorageType = StorageType.Uncompress,
+                            FileContent = "File Contents"
+                        }]
+                    }],
+                    Files = []
+                }
+            }
+        ]);
+
+        using (var archive = new SgaArchive(stream, SgaMode.Write, SgaVersion.V2, parser))
+        {
+            SgaDrive drive = archive.AddDrive("DriveAlias", "DriveName");
+            drive.RootFolder.Name = "";
+            SgaFolder data = drive.RootFolder.AddFolder("Data");
+            SgaFile file1 = data.AddFile("File1", StorageType.StreamCompress);
+            
+            using(var contents = file1.Open()){
+                byte[] inputBytes = Encoding.UTF8.GetBytes("File Contents");
+                contents.Write(inputBytes);
+            }
+
+            file1.StorageType = StorageType.Uncompress;   
+        }
+    }
+
+    [Fact]
+    public void ChangeFileStorageType_ToCompressed_WhenContentNotLoaded_CompressesContents()
+    {
+        var stream = new MemoryStream();
+        var parser = new MockParser([
+            new TestDrive{
+                Name = "DriveName",
+                Alias = "DriveAlias",
+                RootFolder = new TestFolder{
+                    Name = "",
+                    Folders = [new TestFolder{
+                        Name= "Data",
+                        Folders = [],
+                        Files = [new TestFile{
+                            Name= "File1",
+                            StorageType = StorageType.Uncompress,
+                            FileContent = "File Contents"
+                        }]
+                    }],
+                    Files = []
+                }
+            }
+        ],[
+            new TestDrive{
+                Name = "DriveName",
+                Alias = "DriveAlias",
+                RootFolder = new TestFolder{
+                    Name = "",
+                    Folders = [new TestFolder{
+                        Name= "Data",
+                        Folders = [],
+                        Files = [new TestFile{
+                            Name= "File1",
+                            StorageType = StorageType.StreamCompress,
+                            FileContent = "File Contents"
+                        }]
+                    }],
+                    Files = []
+                }
+            }
+        ]);
+
+        using (var archive = new SgaArchive(stream, SgaMode.Write, SgaVersion.V2, parser))
+        {
+            SgaDrive drive = archive.GetDrive("DriveAlias")!;
+            SgaFolder data = (SgaFolder)drive.RootFolder.Contents[0];
+            SgaFile file1 = (SgaFile)data.Contents[0];
+
+            file1.StorageType = StorageType.StreamCompress;
+        }
+    }
+
+    [Fact]
+    public void ChangeFileStorageType_ToUncompressed_WhenContentNotLoaded_DecompressesContents()
+    {
+                var stream = new MemoryStream();
+        var parser = new MockParser([
+            new TestDrive{
+                Name = "DriveName",
+                Alias = "DriveAlias",
+                RootFolder = new TestFolder{
+                    Name = "",
+                    Folders = [new TestFolder{
+                        Name= "Data",
+                        Folders = [],
+                        Files = [new TestFile{
+                            Name= "File1",
+                            StorageType = StorageType.StreamCompress,
+                            FileContent = "File Contents"
+                        }]
+                    }],
+                    Files = []
+                }
+            }
+        ],[
+            new TestDrive{
+                Name = "DriveName",
+                Alias = "DriveAlias",
+                RootFolder = new TestFolder{
+                    Name = "",
+                    Folders = [new TestFolder{
+                        Name= "Data",
+                        Folders = [],
+                        Files = [new TestFile{
+                            Name= "File1",
+                            StorageType = StorageType.Uncompress,
+                            FileContent = "File Contents"
+                        }]
+                    }],
+                    Files = []
+                }
+            }
+        ]);
+
+        using (var archive = new SgaArchive(stream, SgaMode.Write, SgaVersion.V2, parser))
+        {
+            SgaDrive drive = archive.GetDrive("DriveAlias")!;
+            SgaFolder data = (SgaFolder)drive.RootFolder.Contents[0];
+            SgaFile file1 = (SgaFile)data.Contents[0];
+
+            file1.StorageType = StorageType.Uncompress;
         }
     }
 

--- a/tests/SgaArchiveTest.cs
+++ b/tests/SgaArchiveTest.cs
@@ -261,7 +261,7 @@ public class SgaArchiveTest
                         new TestFile{
                             Name = "TestFile.txt",
                             StorageType = StorageType.Uncompress,
-                            FileContent = ""
+                            FileContent = "File Contents"
                         }
                     ]
                 }
@@ -283,6 +283,17 @@ public class SgaArchiveTest
             Assert.Equal(StorageType.Uncompress, newFile.StorageType);
             Assert.Same(drive.RootFolder, newFile.Parent);
             Assert.Same(drive, newFile.Drive);
+            Assert.Equal(0u, newFile.CompressedSize);
+            Assert.Equal(0u, newFile.Size);
+
+            using(var fileContent = newFile.Open())
+            {
+                byte[] inputBytes = Encoding.UTF8.GetBytes("File Contents");
+                fileContent.Write(inputBytes);
+            }
+
+            Assert.Equal(13u, newFile.CompressedSize);
+            Assert.Equal(13u, newFile.Size);
         }
     }
 
@@ -326,6 +337,7 @@ public class SgaArchiveTest
             }
         ]);
 
+        // TODO: Add writing into the file.
         using (var archive = new SgaArchive(stream, SgaMode.Create, SgaVersion.V2, parser))
         {
             SgaDrive drive = archive.AddDrive("Alias", "Name");

--- a/tests/SgaArchiveTest.cs
+++ b/tests/SgaArchiveTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System.Reflection.Metadata.Ecma335;
+using System.Runtime.CompilerServices;
+using System.Text;
 using Xunit.Sdk;
 
 
@@ -385,6 +387,72 @@ public class SgaArchiveTest
         }
     }
 
+    [Fact]
+    public void ChangeName_InEditMode_ChangesPathAsWell()
+    {
+        var stream = new MemoryStream();
+        var parser = new MockParser([
+            new TestDrive{
+                Name = "DriveName",
+                Alias = "DriveAlias",
+                RootFolder = new TestFolder{
+                    Name = "",
+                    Folders = [new TestFolder{
+                        Name= "SubFolder",
+                        Folders = [new TestFolder{
+                            Name = "SubSubFolder",
+                            Folders = [],
+                            Files = []
+                        }],
+                        Files = []
+                    }],
+                    Files = []
+                }
+            }
+        ],[
+            new TestDrive{
+                Name = "DriveName",
+                Alias = "DriveAlias",
+                RootFolder = new TestFolder{
+                    Name = "",
+                    Folders = [new TestFolder{
+                        Name= "Data",
+                        Folders = [new TestFolder{
+                            Name = "MyFolder",
+                            Folders = [],
+                            Files = []
+                        }],
+                        Files = []
+                    }],
+                    Files = []
+                }
+            }
+        ]);
+
+        using (var archive = new SgaArchive(stream, SgaMode.Write, SgaVersion.V2, parser))
+        {
+            SgaDrive drive = archive.Drives[0];
+            SgaFolder data = (SgaFolder)drive.RootFolder.Contents[0];
+            SgaFolder myFolder = (SgaFolder)data.Contents[0];
+
+            Assert.Equal("SubFolder", data.Name);
+            Assert.Equal("SubFolder", data.Path);
+
+            Assert.Equal("SubSubFolder", myFolder.Name);
+            Assert.Equal("SubFolder\\SubSubFolder", myFolder.Path);
+
+            data.Name = "Data";
+            myFolder.Name = "MyFolder";
+
+            Assert.Equal("Data", data.Name);
+            Assert.Equal("Data", data.Path);
+
+            Assert.Equal("MyFolder", myFolder.Name);
+            Assert.Equal("Data\\MyFolder", myFolder.Path);
+
+        }
+    }
+
     #endregion
 
     #region Delete Tests
@@ -680,5 +748,4 @@ public class SgaArchiveTest
 
     #endregion
 }
-
 

--- a/tests/mockParser.cs
+++ b/tests/mockParser.cs
@@ -1,7 +1,6 @@
 using System.IO.Compression;
 using System.Text;
 using OpenCompote.SGA.Parsers;
-using Xunit;
 
 namespace OpenCompote.SGA.Tests;
 
@@ -71,9 +70,7 @@ public class MockParser : ISgaParser
                 compressedSize = (uint)_testStream.Length - dataOffset;
             }
 
-            SgaFile file = new (testFile.Name, testFile.StorageType, dataOffset, compressedSize, size);
-            file.Drive = drive;
-            file.Parent = folder;
+            SgaFile file = new (testFile.Name, testFile.StorageType, dataOffset, compressedSize, size, drive, folder);
             folder._contents.Add(file);
         }
 
@@ -94,6 +91,12 @@ public class MockParser : ISgaParser
     public static void Assert_Folder(TestFolder expectedFolder, SgaFolder actualFolder, SgaFolder? expectedParent, SgaDrive expectedDrive )
     {
         Assert.Equal(expectedFolder.Name, actualFolder.Name);
+
+        string expectedPath;
+        if(expectedParent == null || expectedParent.Path == "")
+            expectedPath = expectedFolder.Name;
+        else
+            expectedPath = expectedParent.Path + '\\' + expectedFolder.Name;
 
         Assert.Same(expectedParent, actualFolder.Parent);
         Assert.Same(expectedDrive, actualFolder.Drive);
@@ -126,6 +129,7 @@ public class MockParser : ISgaParser
         byte[] expectedBytes = Encoding.UTF8.GetBytes(expectedFile.FileContent);
         uint expectedSize = (uint)expectedBytes.Length;
         uint expectedCompressedSize = expectedSize;
+        var expectedPath = expectedParent?.Path + '\\' + expectedFile.Name;
 
         if(expectedFile.StorageType != StorageType.Uncompress)
         {
@@ -138,6 +142,7 @@ public class MockParser : ISgaParser
         }
 
         Assert.Equal(expectedFile.Name, actualFile.Name);
+        Assert.Equal(expectedPath, actualFile.Path);
         Assert.Equal(expectedFile.StorageType, actualFile.StorageType);
         Assert.Equal(expectedSize, actualFile.Size);
         Assert.Equal(expectedCompressedSize, actualFile.CompressedSize);

--- a/tests/mockParser.cs
+++ b/tests/mockParser.cs
@@ -141,9 +141,21 @@ public class MockParser : ISgaParser
         Assert.Same(expectedParent, actualFile.Parent);
         Assert.Same(expectedDrive, actualFile.Drive);
 
-        Stream stream = actualFile.Open();
-        var buffer = new byte [actualFile.Size];
-        stream.ReadExactly(buffer);
+        Stream stream = actualFile.GetResultStream();
+        byte[] buffer = new byte [actualFile.Size];
+
+        if(stream != null)
+        {
+            if(actualFile.StorageType != StorageType.Uncompress)
+            {
+                using var zLib = new ZLibStream(stream, CompressionMode.Decompress);
+                zLib.ReadExactly(buffer);
+            }
+            else
+                stream.ReadExactly(buffer);
+
+        }
+
         string actualContents = Encoding.Default.GetString(buffer);
 
         Assert.Equal(expectedFile.FileContent, actualContents);

--- a/tests/mockParser.cs
+++ b/tests/mockParser.cs
@@ -91,13 +91,6 @@ public class MockParser : ISgaParser
     public static void Assert_Folder(TestFolder expectedFolder, SgaFolder actualFolder, SgaFolder? expectedParent, SgaDrive expectedDrive )
     {
         Assert.Equal(expectedFolder.Name, actualFolder.Name);
-
-        string expectedPath;
-        if(expectedParent == null || expectedParent.Path == "")
-            expectedPath = expectedFolder.Name;
-        else
-            expectedPath = expectedParent.Path + '\\' + expectedFolder.Name;
-
         Assert.Same(expectedParent, actualFolder.Parent);
         Assert.Same(expectedDrive, actualFolder.Drive);
 
@@ -129,7 +122,6 @@ public class MockParser : ISgaParser
         byte[] expectedBytes = Encoding.UTF8.GetBytes(expectedFile.FileContent);
         uint expectedSize = (uint)expectedBytes.Length;
         uint expectedCompressedSize = expectedSize;
-        var expectedPath = expectedParent?.Path + '\\' + expectedFile.Name;
 
         if(expectedFile.StorageType != StorageType.Uncompress)
         {
@@ -142,7 +134,6 @@ public class MockParser : ISgaParser
         }
 
         Assert.Equal(expectedFile.Name, actualFile.Name);
-        Assert.Equal(expectedPath, actualFile.Path);
         Assert.Equal(expectedFile.StorageType, actualFile.StorageType);
         Assert.Equal(expectedSize, actualFile.Size);
         Assert.Equal(expectedCompressedSize, actualFile.CompressedSize);


### PR DESCRIPTION
Added basic implementation of the SGA V2 writer. Currently, the writer can only write existing files, so when I open an existing SGA file in edit mode and do not change anything, the written output is a valid SGA file. 

But before this will be ready to merge, I want to add:

- [x] SgaEntry path string - String will contain the full path of the file/folder and change the V2 parser to populate it.
- [x] Update file content storage so I can actually store changed files.
- [x] Clenup writer code.
- [ ] Add V2 writer and parser test. - Moved to next PR